### PR TITLE
Removed additional.bundles statements

### DIFF
--- a/org.eclipse.january.geometry.xtext.iges/META-INF/MANIFEST.MF
+++ b/org.eclipse.january.geometry.xtext.iges/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.january.geometry.xtext.iges
 Bundle-Vendor: My Company
-Bundle-Version: 2.1.8.qualifier
+Bundle-Version: 1.0.0.qualifier
 Bundle-SymbolicName: org.eclipse.january.geometry.xtext.iges; singleton:=true
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/org.eclipse.january.geometry.xtext.iges/META-INF/MANIFEST.MF
+++ b/org.eclipse.january.geometry.xtext.iges/META-INF/MANIFEST.MF
@@ -2,10 +2,20 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.january.geometry.xtext.iges
 Bundle-Vendor: My Company
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 2.1.8.qualifier
 Bundle-SymbolicName: org.eclipse.january.geometry.xtext.iges; singleton:=true
 Bundle-ActivationPolicy: lazy
-Require-Bundle: org.eclipse.xtext,
- org.eclipse.xtext.xbase,
- org.eclipse.equinox.common;bundle-version="3.5.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Export-Package: org.eclipse.january.geometry.xtext
+Import-Package: com.google.inject,
+ org.apache.commons.logging,
+ org.apache.log4j,
+ org.eclipse.emf.common.notify,
+ org.eclipse.emf.ecore,
+ org.eclipse.xtext,
+ org.eclipse.xtext.common.types,
+ org.eclipse.xtext.xbase,
+ org.objectweb.asm
+Require-Bundle: org.eclipse.emf.ecore;bundle-version="2.12.0",
+ org.eclipse.xtext;bundle-version="2.10.0",
+ org.eclipse.xtext.xtext.generator;bundle-version="2.10.0"

--- a/org.eclipse.january.geometry.xtext.iges/build.properties
+++ b/org.eclipse.january.geometry.xtext.iges/build.properties
@@ -11,18 +11,9 @@
 source.. = src/,\
            src-gen/,\
            xtend-gen/
-bin.includes = .,\
+bin.includes = model/generated/,\
+               .,\
                META-INF/,\
                plugin.xml,\
-               about.html
-additional.bundles = org.eclipse.xtext.xbase,\
-                     org.eclipse.xtext.common.types,\
-                     org.eclipse.xtext.xtext.generator,\
-                     org.eclipse.emf.codegen.ecore,\
-                     org.eclipse.emf.mwe.utils,\
-                     org.eclipse.emf.mwe2.launch,\
-                     org.eclipse.emf.mwe2.lib,\
-                     org.objectweb.asm,\
-                     org.apache.commons.logging,\
-                     org.apache.log4j,\
-                     com.ibm.icu
+               about.html,\
+               license.html

--- a/org.eclipse.january.geometry/META-INF/MANIFEST.MF
+++ b/org.eclipse.january.geometry/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.january.geometry.model;singleton:=true
-Bundle-Version: 2.1.8.qualifier
+Bundle-Version: 1.0.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/org.eclipse.january.geometry/META-INF/MANIFEST.MF
+++ b/org.eclipse.january.geometry/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.january.geometry.model;singleton:=true
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 2.1.8.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
@@ -19,20 +19,27 @@ Export-Package: org.eclipse.january.geometry,
  xtext.generator,
  xtext.formatting,
  xtext.scoping
-Require-Bundle: org.eclipse.core.runtime,
- org.eclipse.emf.ecore;visibility:=reexport,
- org.eclipse.xtext.xbase.lib,
- org.antlr.runtime,
- org.eclipse.xtext.util,
- org.eclipse.xtend.lib,
- org.eclipse.xtext
 Bundle-ActivationPolicy: lazy
 Import-Package: com.google.inject,
  com.google.inject.name;version="1.3.0",
+ org.apache.commons.logging,
  org.apache.log4j,
+ org.eclipse.emf.codegen.ecore,
+ org.eclipse.emf.common.util,
+ org.eclipse.emf.ecore,
+ org.eclipse.emf.mwe2.launch.runtime,
+ org.eclipse.emf.mwe2.launch.ui,
+ org.eclipse.emf.mwe2.launch.ui.shortcut,
+ org.eclipse.swt.widgets,
  org.eclipse.xtext,
  org.eclipse.xtext.formatting.impl,
  org.eclipse.xtext.resource,
  org.eclipse.xtext.services,
  org.eclipse.xtext.util,
+ org.eclipse.xtext.xbase,
+ org.eclipse.xtext.xtext.generator,
+ org.objectweb.asm,
  org.slf4j
+Require-Bundle: org.eclipse.emf.ecore;bundle-version="2.12.0",
+ org.eclipse.xtext;bundle-version="2.10.0",
+ org.eclipse.xtext.generator;bundle-version="2.10.0"

--- a/org.eclipse.january.geometry/build.properties
+++ b/org.eclipse.january.geometry/build.properties
@@ -15,21 +15,10 @@ bin.includes = .,\
                META-INF/,\
                plugin.xml,\
                plugin.properties,\
-               about.html
+               about.html,\
+               license.html
 jars.compile.order = .
 source.. = src/,\
            src-gen/,\
            xtend-gen/
 output.. = bin/
-additional.bundles = org.eclipse.xtext.xbase,\
-                     org.eclipse.xtext.common.types,\
-                     org.eclipse.xtext.xtext.generator,\
-                     org.eclipse.emf.codegen.ecore,\
-                     org.eclipse.emf.mwe.utils,\
-                     org.eclipse.emf.mwe2.launch,\
-                     org.eclipse.emf.mwe2.lib,\
-                     org.objectweb.asm,\
-                     org.apache.commons.logging,\
-                     org.apache.log4j,\
-                     com.ibm.icu,\
-org.eclipse.xtext.generator

--- a/org.eclipse.january.geometry/plugin.properties
+++ b/org.eclipse.january.geometry/plugin.properties
@@ -10,15 +10,5 @@
 ###############################################################################
 #
 
-bin.includes = .,\
-               model/,\
-               META-INF/,\
-               plugin.xml,\
-               plugin.properties,\
-               about.html,\
-               license.html
-jars.compile.order = .
-source.. = src/,\
-           src-gen/,\
-           xtend-gen/
-output.. = bin/
+pluginName = Geometry Model
+providerName = www.example.org

--- a/org.eclipse.january.geometry/plugin.properties
+++ b/org.eclipse.january.geometry/plugin.properties
@@ -10,5 +10,15 @@
 ###############################################################################
 #
 
-pluginName = Geometry Model
-providerName = www.example.org
+bin.includes = .,\
+               model/,\
+               META-INF/,\
+               plugin.xml,\
+               plugin.properties,\
+               about.html,\
+               license.html
+jars.compile.order = .
+source.. = src/,\
+           src-gen/,\
+           xtend-gen/
+output.. = bin/


### PR DESCRIPTION
Removed additional.bundles statements from the build.properties,
replacing them with imports in the manifest files. 

This addresses issue #2 

Signed-off-by: Robert Smith <smithrw@ornl.gov>