### PR TITLE
Issue30 metadata

### DIFF
--- a/org.eclipse.january.test/src/org/eclipse/january/metadata/AllSuite.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/metadata/AllSuite.java
@@ -18,6 +18,7 @@ import org.junit.runners.Suite.SuiteClasses;
 
 @RunWith(TestUtils.VerboseSuite.class)
 @SuiteClasses({ MetadataProviderTest.class,
+	PlainMetadataTest.class,
 	org.eclipse.january.metadata.internal.AllSuite.class,
 	})
 public class AllSuite {

--- a/org.eclipse.january.test/src/org/eclipse/january/metadata/PlainMetadataTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/metadata/PlainMetadataTest.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Diamond Light Source Ltd. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.january.metadata;
+
+import org.eclipse.january.MetadataException;
+import org.eclipse.january.dataset.Dataset;
+import org.eclipse.january.dataset.DatasetFactory;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class PlainMetadataTest {
+
+	@Test
+	public void testPlainMetadata() throws MetadataException {
+		Dataset mdp = DatasetFactory.zeros(2, 3);
+
+		// check empty
+		Assert.assertNull("Metadata should be empty", mdp.getMetadata());
+		Assert.assertNull("Metadata should be empty", mdp.getMetadata(PlainMetadata.class));
+		
+		// set metadata
+		mdp.setMetadata(new PlainMetadata());
+		
+		// check not empty
+		Assert.assertNotNull("Metadata should not be empty (general)", mdp.getMetadata());
+		Assert.assertNotNull("Metadata should not be empty (specific)", mdp.getMetadata(PlainMetadata.class));
+		Assert.assertNull("Metadata should be empty (type not present)", mdp.getMetadata(Metadata.class));
+	}
+
+	protected class PlainMetadata implements MetadataType
+	{
+
+		/**
+		 * 
+		 */
+		private static final long serialVersionUID = 1L;
+		
+		public PlainMetadata clone()
+		{
+			return new PlainMetadata();
+		}
+		
+	}
+	
+}

--- a/org.eclipse.january.test/src/org/eclipse/january/metadata/PlainMetadataTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/metadata/PlainMetadataTest.java
@@ -13,6 +13,10 @@ import org.eclipse.january.dataset.DatasetFactory;
 import org.junit.Assert;
 import org.junit.Test;
 
+/** test class introduced to verify performance of relaxed implementation of IDataset.getMetadata() which 
+ * now matches signature of IDataset.setMetadata()
+ *
+ */
 public class PlainMetadataTest {
 
 	@Test
@@ -34,7 +38,6 @@ public class PlainMetadataTest {
 
 	protected class PlainMetadata implements MetadataType
 	{
-
 		/**
 		 * 
 		 */

--- a/org.eclipse.january/src/org/eclipse/january/dataset/IDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/IDataset.java
@@ -14,7 +14,7 @@ package org.eclipse.january.dataset;
 
 import java.text.Format;
 
-import org.eclipse.january.metadata.IMetadata;
+import org.eclipse.january.metadata.MetadataType;
 
 
 /**
@@ -166,7 +166,7 @@ public interface IDataset extends ILazyDataset {
 	 * @return the metadata, may be null
 	 */
 	@Override
-	public IMetadata getMetadata();
+	public MetadataType getMetadata();
 
 	@Override
 	public IDataset getSlice(int[] start, int[] stop, int[] step);

--- a/org.eclipse.january/src/org/eclipse/january/dataset/IMetadataProvider.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/IMetadataProvider.java
@@ -15,7 +15,6 @@ package org.eclipse.january.dataset;
 import java.util.List;
 
 import org.eclipse.january.MetadataException;
-import org.eclipse.january.metadata.IMetadata;
 import org.eclipse.january.metadata.MetadataType;
 
 /**
@@ -27,7 +26,7 @@ public interface IMetadataProvider {
 	 * @return an instance of IMetadata
 	 * @throws Exception
 	 */
-	public IMetadata getMetadata() throws Exception;
+	public MetadataType getMetadata() throws Exception;
 
 	/**
 	 * @param clazz if null return everything

--- a/org.eclipse.january/src/org/eclipse/january/dataset/LazyDatasetBase.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/LazyDatasetBase.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import org.eclipse.january.DatasetException;
 import org.eclipse.january.MetadataException;
 import org.eclipse.january.metadata.ErrorMetadata;
-import org.eclipse.january.metadata.IMetadata;
 import org.eclipse.january.metadata.MetadataFactory;
 import org.eclipse.january.metadata.MetadataType;
 import org.eclipse.january.metadata.Reshapeable;
@@ -154,8 +153,8 @@ public abstract class LazyDatasetBase implements ILazyDataset, Serializable {
 	}
 
 	@Override
-	public IMetadata getMetadata() {
-		List<? extends IMetadata> ml = getAllMetadata(IMetadata.class);
+	public MetadataType getMetadata() {
+		List<? extends MetadataType> ml = getAllMetadata(MetadataType.class);
 
 		return ml == null || ml.isEmpty() ? null : ml.get(0);
 	}


### PR DESCRIPTION
Fix for IDataset getter & setter methods not being symmetric:
https://github.com/eclipse/january/issues/30

All ````org.eclipse.january.test```` tests still run successfully.

In this change, ````IDataset.getMetadata()```` now returns the more generic [MetadataType](https://github.com/eclipse/january/blob/master/org.eclipse.january/src/org/eclipse/january/metadata/MetadataType.java) than the previous [IMetadata](https://github.com/eclipse/january/blob/master/org.eclipse.january/src/org/eclipse/january/metadata/IMetadata.java) type, which contains implementation details (file location, etc).

I suspect the changed return signature for ````IDataset.getMetadata()```` will not break any existing implementations, since they will most probably be expecting ````IMetadata```` style of metadata.

But, existing implementations may fail if/when more generic ````MetadataType```` metadata objects are added (such as those necessary to support Units of Measurement metadata).

So, if existing implementations expecting ````IMetadata```` use ````IDataset.getMetadata(IMetadata.class);```` they will still work without further modification.