### PR TITLE
Tighten position accessor requirements

### DIFF
--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/AbstractCompoundDatasetTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/AbstractCompoundDatasetTest.java
@@ -638,7 +638,7 @@ public class AbstractCompoundDatasetTest {
 		
 		// should be squared
 		CompoundDataset e = (CompoundDataset) a.getErrorBuffer();
-		double[] ea = e.getDoubleArray();
+		double[] ea = e.getDoubleArray(0);
 		assertEquals(1.0, ea[0], 0.001);
 		assertEquals(4.0, ea[1], 0.001);
 		assertEquals(9.0, ea[2], 0.001);

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/AbstractDatasetTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/AbstractDatasetTest.java
@@ -324,10 +324,10 @@ public class AbstractDatasetTest {
 		assertEquals("0,3 element", 7, a.getDouble(0,3), 1e-6);
 		assertTrue("Final element", Double.isNaN(a.getDouble(2,3)));
 
-		a.set(12, 0);
+		a.set(12, 0, 0);
 		a.sort(null);
 		TestUtils.verbosePrintf("%s\n", a.toString());
-		assertEquals("First element", 2, a.getDouble(0), 1e-6);
+		assertEquals("First element", 2, a.getDouble(0, 0), 1e-6);
 		assertEquals("2,2 element", 12, a.getDouble(2,2), 1e-6);
 		assertTrue("Final element", Double.isNaN(a.getDouble(2,3)));
 

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/BroadcastIteratorTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/BroadcastIteratorTest.java
@@ -120,7 +120,7 @@ public class BroadcastIteratorTest {
 		for (int j = 0; j < 6; j++) {
 			Assert.assertTrue(it.hasNext());
 			c.set(it.aDouble * it.bDouble, j);
-			Assert.assertEquals(a.getDouble(), it.aDouble, 1e-15);
+			Assert.assertEquals(a.getDouble(0), it.aDouble, 1e-15);
 			Assert.assertEquals(b.getDouble(j), it.bDouble, 1e-15);
 			Assert.assertEquals(c.getDouble(j), (j + 2.0), 1e-15);
 		}

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/DoubleDatasetTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/DoubleDatasetTest.java
@@ -11,6 +11,7 @@ package org.eclipse.january.dataset;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import org.eclipse.january.dataset.Dataset;
 import org.eclipse.january.dataset.DatasetFactory;
@@ -71,6 +72,43 @@ public class DoubleDatasetTest {
 		for (int i = 0; i < l; i++) {
 			double r = sc.getDouble(-(i + 1));
 			assertEquals(r, sv.getDouble(-(i + 1)), 1e-5 * r);
+		}
+
+		try {
+			a.getDouble();
+			fail("Should have thrown an IAE");
+		} catch (IllegalArgumentException e) {
+		}
+
+		try {
+			a.getDouble(null);
+			fail("Should have thrown an NPE");
+		} catch (NullPointerException e) {
+		}
+
+		try {
+			a.getDouble(new int[2]);
+			fail("Should have thrown an IAE");
+		} catch (IllegalArgumentException e) {
+		}
+
+		try {
+			a.getDouble(0, 0);
+			fail("Should have thrown a UOE");
+		} catch (UnsupportedOperationException e) {
+		}
+
+		Dataset b = a.reshape(4, 3);
+		try {
+			b.getDouble(new int[1]);
+			fail("Should have thrown an IAE");
+		} catch (IllegalArgumentException e) {
+		}
+
+		try {
+			b.getDouble(0);
+			fail("Should have thrown a UOE");
+		} catch (UnsupportedOperationException e) {
 		}
 	}
 
@@ -159,9 +197,9 @@ public class DoubleDatasetTest {
 		b = a.sum(2);
 		assertEquals(2, b.getRank());
 		assertArrayEquals(new int[] { 3, 1 }, b.getShape());
-		assertEquals(6., b.getDouble(0), 1e-6);
-		assertEquals(22., b.getDouble(1), 1e-6);
-		assertEquals(38., b.getDouble(2), 1e-6);
+		assertEquals(6., b.getDouble(0, 0), 1e-6);
+		assertEquals(22., b.getDouble(1, 0), 1e-6);
+		assertEquals(38., b.getDouble(2, 0), 1e-6);
 	}
 
 	@Test

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/LazyDynamicLoaderTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/LazyDynamicLoaderTest.java
@@ -49,8 +49,8 @@ public class LazyDynamicLoaderTest {
 			
 			AxesMetadata axm = s.getFirstMetadata(AxesMetadata.class);
 			
-			Assert.assertEquals(axm.getAxis(0)[0].getSlice().getInt(0),shape[0]-1);
-			Assert.assertEquals(axm.getAxis(1)[0].getSlice().getInt(0),shape[1]-1);
+			Assert.assertEquals(axm.getAxis(0)[0].getSlice().getInt(0, 0, 0, 0), shape[0]-1);
+			Assert.assertEquals(axm.getAxis(1)[0].getSlice().getInt(0, 0, 0, 0), shape[1]-1);
 			
 			dataset.refreshShape();
 		}
@@ -95,10 +95,10 @@ public class LazyDynamicLoaderTest {
 
 			IDataset s0 = axm.getAxis(0)[0].getSlice();
 			Assert.assertArrayEquals(axShape, s0.getShape());
-			Assert.assertEquals(s0.getInt(0),shape[0]-1);
+			Assert.assertEquals(s0.getInt(0, 0, 0, 0), shape[0]-1);
 			s0 = axm.getAxis(1)[0].getSlice();
 			Assert.assertArrayEquals(axShape, s0.getShape());
-			Assert.assertEquals(axm.getAxis(1)[0].getSlice().getInt(0),shape[1]-1);
+			Assert.assertEquals(axm.getAxis(1)[0].getSlice().getInt(0, 0, 0, 0), shape[1]-1);
 
 			dataset.refreshShape();
 		}

--- a/org.eclipse.january/src/org/eclipse/january/dataset/AbstractDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/AbstractDataset.java
@@ -899,16 +899,8 @@ public abstract class AbstractDataset extends LazyDatasetBase implements Dataset
 
 	@Override
 	public int get1DIndex(final int... n) {
-		final int imax = n.length;
-		final int rank = shape.length;
-		if (imax == 0) {
-			if (rank == 0 || (rank == 1 && shape[0] <= 1))
-				return stride == null ? 0 : offset;
-			throw new IllegalArgumentException("One or more index parameters must be supplied");
-		} else if (imax > rank) {
-			throw new IllegalArgumentException("No of index parameters is different to the shape of data: " + imax
-					+ " given " + rank + " required");
-		}
+		if (n.length == 0 && shape.length == 0)
+			return offset;
 
 		return stride == null ? get1DIndexFromShape(n) : get1DIndexFromStrides(n);
 	}
@@ -924,9 +916,8 @@ public abstract class AbstractDataset extends LazyDatasetBase implements Dataset
 	 */
 	protected int get1DIndex(int i) {
 		if (shape.length > 1) {
-			logger.debug("This dataset is not 1D but was addressed as such");
-//			throw new IllegalArgumentException("This dataset is not 1D but was addressed as such");
-			return get1DIndex(new int[] {i});
+			logger.error("This dataset is not 1D but was addressed as such");
+			throw new UnsupportedOperationException("This dataset is not 1D but was addressed as such");
 		}
 		if (i < 0) {
 			i += shape[0];
@@ -944,9 +935,8 @@ public abstract class AbstractDataset extends LazyDatasetBase implements Dataset
 	 */
 	protected int get1DIndex(int i, int j) {
 		if (shape.length != 2) {
-			logger.debug("This dataset is not 2D but was addressed as such");
-//			throw new IllegalArgumentException("This dataset is not 2D but was addressed as such");
-			return get1DIndex(new int[] {i, j});
+			logger.error("This dataset is not 2D but was addressed as such");
+			throw new UnsupportedOperationException("This dataset is not 2D but was addressed as such");
 		}
 		if (i < 0) {
 			i += shape[0];
@@ -968,14 +958,14 @@ public abstract class AbstractDataset extends LazyDatasetBase implements Dataset
 	}
 
 	protected static int get1DIndexFromShape(final int[] shape, final int[] n) {
-		final int imax = n.length;
 		final int rank = shape.length;
-//		if (rank != imax) {
-//			throw new IllegalArgumentException("Number of position indexes must be equal to rank");
-//		}
+		if (rank != n.length) {
+			String errMsg = String.format("Number of position values must be equal to rank of %d", rank);
+			logger.error(errMsg);
+			throw new IllegalArgumentException(errMsg);
+		}
 		int index = 0;
-		int i = 0;
-		for (; i < imax; i++) {
+		for (int i = 0; i < rank; i++) {
 			final int si = shape[i];
 			int ni = n[i];
 			if (ni < 0) {
@@ -985,9 +975,6 @@ public abstract class AbstractDataset extends LazyDatasetBase implements Dataset
 				throwAIOOBException(ni, si, i);
 			}
 			index = index * si + ni;
-		}
-		for (; i < rank; i++) {
-			index *= shape[i];
 		}
 
 		return index;
@@ -1000,7 +987,9 @@ public abstract class AbstractDataset extends LazyDatasetBase implements Dataset
 	private static int get1DIndexFromStrides(final int[] shape, final int[] stride, final int offset, final int[] n) {
 		final int rank = shape.length;
 		if (rank != n.length) {
-			throw new IllegalArgumentException("Number of position indexes must be equal to rank");
+			String errMsg = String.format("Number of position values must be equal to rank of %d", rank);
+			logger.error(errMsg);
+			throw new IllegalArgumentException(errMsg);
 		}
 		int index = offset;
 		for (int i = 0; i < rank; i++) {


### PR DESCRIPTION
Position arrays must have lengths that match dataset rank and rank-specific accessors succeed only when called on matching datasets