### PR TITLE
Fix setting slice with an incompatible shape

### DIFF
--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/AbstractDatasetTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/AbstractDatasetTest.java
@@ -1245,6 +1245,12 @@ public class AbstractDatasetTest {
 		assertEquals(13, a.getDouble(2, 3), 1e-15);
 		assertEquals(2, a.getDouble(2, 4), 1e-15);
 
+		try {
+			a.setSlice(DatasetFactory.createRange(3, Dataset.INT16), new Slice(2, 7, 2), new Slice(2, 3));
+			fail("Should have thrown an IAE");
+		} catch (IllegalArgumentException e) {
+		}
+
 		// compound
 		CompoundDataset c = DatasetFactory.createRange(3, 100, Dataset.ARRAYFLOAT64).reshape(20, 5);
 		c.setSlice(DatasetFactory.createRange(3, Dataset.INT16), new Slice(2, 10), new Slice(null, null, 2));

--- a/org.eclipse.january/src/org/eclipse/january/dataset/BroadcastSingleIterator.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/BroadcastSingleIterator.java
@@ -15,7 +15,6 @@ import java.util.List;
  * Class to run over a pair of datasets in parallel with NumPy broadcasting of second dataset
  */
 public class BroadcastSingleIterator extends BroadcastSelfIterator {
-	private int[] aShape;
 	private int[] bShape;
 	private int[] aStride;
 	private int[] bStride;
@@ -34,19 +33,18 @@ public class BroadcastSingleIterator extends BroadcastSelfIterator {
 	 */
 	public BroadcastSingleIterator(Dataset a, Dataset b) {
 		super(a, b);
-		List<int[]> fullShapes = BroadcastUtils.broadcastShapes(a.getShapeRef(), b.getShapeRef());
 
-		maxShape = fullShapes.remove(0);
-
-		aShape = fullShapes.remove(0);
+		int[] aShape = a.getShapeRef();
+		maxShape = aShape;
+		List<int[]> fullShapes = BroadcastUtils.broadcastShapesToMax(maxShape, b.getShapeRef());
 		bShape = fullShapes.remove(0);
 
 		int rank = maxShape.length;
 		endrank = rank - 1;
 
-		aDataset = a.reshape(aShape);
 		bDataset = b.reshape(bShape);
-		aStride = BroadcastUtils.createBroadcastStrides(aDataset, maxShape);
+		int[] aOffset = new int[1];
+		aStride = AbstractDataset.createStrides(aDataset, aOffset );
 		bStride = BroadcastUtils.createBroadcastStrides(bDataset, maxShape);
 
 		pos = new int[rank];
@@ -73,7 +71,7 @@ public class BroadcastSingleIterator extends BroadcastSelfIterator {
 				}
 			}
 		}
-		aStart = aDataset.getOffset();
+		aStart = aOffset[0];
 		aMax += aStart;
 		bStart = bDataset.getOffset();
 		bMax += bStart;
@@ -126,7 +124,7 @@ public class BroadcastSingleIterator extends BroadcastSelfIterator {
 	 * @return shape of first broadcasted dataset
 	 */
 	public int[] getFirstShape() {
-		return aShape;
+		return maxShape;
 	}
 
 	/**


### PR DESCRIPTION
The broadcast iterator must not broadcast to the destination dataset; only the source dataset should be broadcast