### PR TITLE
nonZero to return empty dataset if no non-zero value in dimension

### DIFF
--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/ComparisonsTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/ComparisonsTest.java
@@ -10,6 +10,7 @@
 package org.eclipse.january.dataset;
 
 import java.util.List;
+import java.util.ArrayList;
 
 import org.eclipse.january.asserts.TestUtils;
 import org.eclipse.january.dataset.BooleanDataset;
@@ -208,6 +209,16 @@ public class ComparisonsTest {
 		List<IntegerDataset> e = Comparisons.nonZero(c);
 		TestUtils.assertDatasetEquals(e.get(0), DatasetFactory.createFromObject(new int[] {0, 0, 1, 1, 1}));
 		TestUtils.assertDatasetEquals(e.get(1), DatasetFactory.createFromObject(new int[] {1, 2, 0, 1, 2}));
+	}
+
+	@Test
+	public void testNoNonZeros() {
+		Dataset c = DatasetFactory.createFromObject(new byte[] { 0, 0, 0, 0, 0, 0 }).reshape(2, 3);
+		List<IntegerDataset> e = Comparisons.nonZero(c);
+		Assert.assertEquals(e.size(), 2);
+		Dataset empty = DatasetFactory.createFromList(Dataset.INT32, new ArrayList<Integer>());
+		TestUtils.assertDatasetEquals(e.get(0), empty);
+		TestUtils.assertDatasetEquals(e.get(1), empty);
 	}
 
 	@Test

--- a/org.eclipse.january/src/org/eclipse/january/dataset/Comparisons.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/Comparisons.java
@@ -1272,12 +1272,8 @@ public class Comparisons {
 			}
 		}
 
-	
-		final int length = indices.get(0).size();
-		if (length > 0 ) {
-			for (int j = 0; j < rank; j++) {
-				indexList.add((IntegerDataset) DatasetFactory.createFromList(indices.get(j)));
-			}
+		for (int j = 0; j < rank; j++) {
+			indexList.add((IntegerDataset) DatasetFactory.createFromList(Dataset.INT32, indices.get(j)));
 		}
 		return indexList;
 	}


### PR DESCRIPTION
Changes nonZero method in Comparisons to return a list of empty datasets
(rank 1, size 0) for each dimension if no non-zero values are present.
This is to be consistent with the usual behaviour (and numpy).

Signed-off-by: Charles Mita <charles.mita@diamond.ac.uk>