### PR TITLE
Suggested javadoc to mark deprecation of legacy methods

### DIFF
--- a/org.eclipse.january/src/org/eclipse/january/dataset/DatasetFactory.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/DatasetFactory.java
@@ -45,7 +45,11 @@ public class DatasetFactory {
 	 * @param step spacing between items
 	 * @param dtype
 	 * @return a new 1D dataset of given type, filled with values determined by parameters
-	 */
+	 * 
+	 * @deprecated Please use the class-based methods in DatasetFactory, 
+	 *             such as {@link #createRange(Class, double, double, double)} 
+	 */	
+	@Deprecated
 	public static Dataset createRange(final double start, final double stop, final double step, final int dtype) {
 		if ((step > 0) != (start <= stop)) {
 			throw new IllegalArgumentException("Invalid parameters: start and stop must be in correct order for step");


### PR DESCRIPTION

## Suggested resolution to marking legacy (non type-checked) methods as deprecated.

*Note: Demonstration PR, not ready for merge*

I think it would be respectful to future adopters to mark the create() methods that were used in the earlier tutorials as deprecated - to gently push them towards the class based dataset generators.  This was briefly discussed here: https://github.com/eclipse/january/issues/24#issuecomment-280679340

If this comment description is valid, then I'm happy to spend a few minutes adding javadoc markers & annotations to the other methods that use the legacy `dtype` data type parameter.  Then I'll update the PR.


Signed-off-by: Ian Mayo <ian@planetmayo.com>