### PR TITLE
Apply deprecated tag to remaining legacy methods

### DIFF
--- a/org.eclipse.january/src/org/eclipse/january/dataset/DatasetFactory.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/DatasetFactory.java
@@ -33,7 +33,11 @@ public class DatasetFactory {
 	 * @param stop
 	 * @param dtype
 	 * @return a new dataset of given shape and type, filled with values determined by parameters
-	 */
+	 * 
+	 * @deprecated Please use the class-based methods in DatasetFactory, 
+	 *             such as {@link #createRange(Class, double)} 
+	 */	
+	@Deprecated
 	public static Dataset createRange(final double stop, final int dtype) {
 		return createRange(0, stop, 1, dtype);
 	}
@@ -84,7 +88,11 @@ public class DatasetFactory {
 	 * @param stop
 	 * @param dtype
 	 * @return a new dataset of given shape and type, filled with values determined by parameters
-	 */
+	 * 
+	 * @deprecated Please use the class-based methods in DatasetFactory, 
+	 *             such as {@link #createRange(Class, double, double, double)} 
+	 */	
+	@Deprecated
 	public static CompoundDataset createRange(final int itemSize, final double stop, final int dtype) {
 		return createRange(itemSize, 0, stop, 1, dtype);
 	}
@@ -97,7 +105,11 @@ public class DatasetFactory {
 	 * @param step spacing between items
 	 * @param dtype
 	 * @return a new 1D dataset of given type, filled with values determined by parameters
-	 */
+	 * 
+	 * @deprecated Please use the class-based methods in DatasetFactory, 
+	 *             such as {@link #createRange(Class, double, double, double)} 
+	 */	
+	@Deprecated
 	public static CompoundDataset createRange(final int itemSize, final double start, final double stop, final double step, final int dtype) {
 		if (itemSize < 1) {
 			throw new IllegalArgumentException("Item size must be greater or equal to 1");
@@ -198,7 +210,11 @@ public class DatasetFactory {
 	 *            can be a Java list, array or Number
 	 * @return dataset
 	 * @throws IllegalArgumentException if dataset type is not known
-	 */
+	 * 
+	 * @deprecated Please use the class-based methods in DatasetFactory, 
+	 *             such as {@link #createFromObject(Class, Object, int)} 
+	 */	
+	@Deprecated
 	public static Dataset createFromObject(final int dtype, final Object obj) {
 		return createFromObject(dtype, obj, null);
 	}
@@ -211,7 +227,11 @@ public class DatasetFactory {
 	 * @param shape can be null
 	 * @return dataset
 	 * @throws IllegalArgumentException if dataset type is not known
-	 */
+	 * 
+	 * @deprecated Please use the class-based methods in DatasetFactory, 
+	 *             such as {@link #createFromObject(Class, Object, int...)} 
+	 */	
+	@Deprecated
 	public static Dataset createFromObject(final int dtype, final Object obj, final int... shape) {
 		return createFromObject(1, dtype, obj, shape);
 	}
@@ -225,7 +245,11 @@ public class DatasetFactory {
 	 * @param shape can be null
 	 * @return dataset
 	 * @throws IllegalArgumentException if dataset type is not known
-	 */
+	 * 
+	 * @deprecated Please use the class-based methods in DatasetFactory, 
+	 *             such as {@link #createFromObject(int, Class, Object, int...)} 
+	 */	
+	@Deprecated
 	public static Dataset createFromObject(final int itemSize, final int dtype, final Object obj, final int... shape) {
 		Dataset d = null;
 
@@ -381,7 +405,11 @@ public class DatasetFactory {
 	 * @param dtype
 	 * @param objectList
 	 * @return dataset filled with values from list
-	 */
+	 * 
+	 * @deprecated Please use the class-based methods in DatasetFactory, 
+	 *             such as {@link #createFromList(Class, List<?>)} 
+	 */	
+	@Deprecated
 	public static Dataset createFromList(final int dtype, List<?> objectList) {
 		int len = objectList.size();
 		Dataset result = zeros(new int[] { len }, dtype);
@@ -412,7 +440,11 @@ public class DatasetFactory {
 	 * @param dtype
 	 * @param objects
 	 * @return compound dataset
-	 */
+	 * 
+	 * @deprecated Please use the class-based methods in DatasetFactory, 
+	 *             such as {@link #createCompoundDataset(Class, Object...)} 
+	 */	
+	@Deprecated
 	public static CompoundDataset createCompoundDataset(final int dtype, Object... objects) {
 		Dataset[] datasets = new Dataset[objects.length];
 		for (int i = 0; i < objects.length; i++) {
@@ -428,7 +460,11 @@ public class DatasetFactory {
 	 * @param real
 	 * @param imag
 	 * @return complex dataset
-	 */
+	 * 
+	 * @deprecated Please use the class-based methods in DatasetFactory, 
+	 *             such as {@link #createComplexDataset(Class, Object, Object)} 
+	 */	
+	@Deprecated
 	public static CompoundDataset createComplexDataset(final int dtype, Object real, Object imag) {
 		switch (dtype) {
 		case Dataset.COMPLEX64:
@@ -452,7 +488,11 @@ public class DatasetFactory {
 	 * @param shape
 	 * @param dtype
 	 * @return a new dataset of given shape and type, filled with zeros
-	 */
+	 * 
+	 * @deprecated Please use the class-based methods in DatasetFactory, 
+	 *             such as {@link #zeros(Class, int...)} 
+	 */	
+	@Deprecated
 	public static Dataset zeros(final int[] shape, final int dtype) {
 		switch (dtype) {
 		case Dataset.BOOL:
@@ -497,7 +537,11 @@ public class DatasetFactory {
 	 * @param shape
 	 * @param dtype
 	 * @return a new dataset of given item size, shape and type, filled with zeros
-	 */
+	 * 
+	 * @deprecated Please use the class-based methods in DatasetFactory, 
+	 *             such as {@link #zeros(int, Class, int...)} 
+	 */	
+	@Deprecated
 	public static Dataset zeros(final int itemSize, final int[] shape, final int dtype) {
 		if (itemSize == 1) {
 			return zeros(shape, dtype);
@@ -511,7 +555,11 @@ public class DatasetFactory {
 	 * @param dtype
 	 * @return a new dataset of given item size, shape and type, filled with zeros
 	 * @since 2.0
-	 */
+	 * 
+	 * @deprecated Please use the class-based methods in DatasetFactory, 
+	 *             such as {@link #compoundZeros(int, Class, int)} 
+	 */	
+	@Deprecated
 	public static CompoundDataset compoundZeros(final int itemSize, final int[] shape, final int dtype) {
 		switch (dtype) {
 		case Dataset.INT8:
@@ -568,7 +616,11 @@ public class DatasetFactory {
 	 * @param dataset
 	 * @param dtype
 	 * @return a new dataset
-	 */
+	 * 
+	 * @deprecated Please use the class-based methods in DatasetFactory, 
+	 *             such as {@link #zeros(Dataset, Class)} 
+	 */	
+	@Deprecated
 	public static Dataset zeros(final Dataset dataset, final int dtype) {
 		final int[] shape = dataset.getShapeRef();
 		final int isize = DTypeUtils.isDTypeElemental(dtype) ? 1 :dataset.getElementsPerItem();
@@ -591,7 +643,11 @@ public class DatasetFactory {
 	 * @param dataset
 	 * @param dtype
 	 * @return a new dataset
-	 */
+	 * 
+	 * @deprecated Please use the class-based methods in DatasetFactory, 
+	 *             such as {@link #createRange(Class, double, double, double)} 
+	 */	
+	@Deprecated
 	public static Dataset ones(final Dataset dataset, final int dtype) {
 		final int[] shape = dataset.getShapeRef();
 		final int isize = DTypeUtils.isDTypeElemental(dtype) ? 1 :dataset.getElementsPerItem();
@@ -611,7 +667,11 @@ public class DatasetFactory {
 	 * @param shape
 	 * @param dtype
 	 * @return a new dataset of given shape and type, filled with ones
-	 */
+	 * 
+	 * @deprecated Please use the class-based methods in DatasetFactory, 
+	 *             such as {@link #ones(int[], Class)} 
+	 */	
+	@Deprecated
 	public static Dataset ones(final int[] shape, final int dtype) {
 		switch (dtype) {
 		case Dataset.BOOL:
@@ -644,7 +704,11 @@ public class DatasetFactory {
 	 * @param shape
 	 * @param dtype
 	 * @return a new dataset of given item size, shape and type, filled with ones
-	 */
+	 * 
+	 * @deprecated Please use the class-based methods in DatasetFactory, 
+	 *             such as {@link #ones(Class, int...)} 
+	 */	
+	@Deprecated
 	public static Dataset ones(final int itemSize, final int[] shape, final int dtype) {
 		if (itemSize == 1) {
 			return ones(shape, dtype);
@@ -695,7 +759,11 @@ public class DatasetFactory {
 	 * @param length number of points
 	 * @param dtype
 	 * @return dataset with linearly spaced values
-	 */
+	 * 
+	 * @deprecated Please use the class-based methods in DatasetFactory, 
+	 *             such as {@link #createLinearSpace(Class, double, double, int)} 
+	 */	
+	@Deprecated
 	public static Dataset createLinearSpace(final double start, final double stop, final int length, final int dtype) {
 		if (length < 1) {
 			throw new IllegalArgumentException("Length is less than one");
@@ -727,7 +795,11 @@ public class DatasetFactory {
 	 * @param base
 	 * @param dtype
 	 * @return dataset with logarithmically spaced values
-	 */
+	 * 
+	 * @deprecated Please use the class-based methods in DatasetFactory, 
+	 *             such as {@link #createLogSpace(Class, double, double, int, double)} 
+	 */	
+	@Deprecated
 	public static Dataset createLogSpace(final double start, final double stop, final int length, final double base, final int dtype) {
 		if (length < 1) {
 			throw new IllegalArgumentException("Length is less than one");


### PR DESCRIPTION
Ok.  Fingers double-crossed this time.

This PR covers the application of the Deprecated tag & annotation to the remaining affected methods. Where possible I've tried to provide a link to the new class-safe alternative method.

Signed-off-by: Ian Mayo <ian@planetmayo.com>