### PR TITLE
Suppress warnings of calls to deprecated methods from mature codebase

### DIFF
--- a/org.eclipse.january.examples/src/org/eclipse/january/examples/dataset/NumpyExamples.java
+++ b/org.eclipse.january.examples/src/org/eclipse/january/examples/dataset/NumpyExamples.java
@@ -392,7 +392,8 @@ public class NumpyExamples {
      * 1:10                                  arange(1.,11.) 
      * 0:9                                   arange(10.)
      */
-    @Test
+    @SuppressWarnings("deprecation")
+	@Test
     public void arange() {
     	IDataset aran = DatasetFactory.createRange(1, 11, 1, Dataset.FLOAT64);
     	System.out.println("arange type notation in dawnsci(1) "+aran);  	
@@ -407,7 +408,8 @@ public class NumpyExamples {
      */
     @Test
     public void columnVector() {
-    	IDataset aran = DatasetFactory.createRange(1, 11, 1, Dataset.FLOAT64);
+    	@SuppressWarnings("deprecation")
+		IDataset aran = DatasetFactory.createRange(1, 11, 1, Dataset.FLOAT64);
     	aran.resize(aran.getSize(), 1);
     }
     
@@ -436,6 +438,7 @@ public class NumpyExamples {
     4 equally spaced samples between 1 and 3, inclusive
     linspace(1,3,4)                          linspace(1,3,4)     
     */
+	@SuppressWarnings("deprecation")
 	@Test
     public void various() {
     	
@@ -456,7 +459,8 @@ public class NumpyExamples {
      */
     @Test
     public void meshGrid() {
-    	List<Dataset> mg = DatasetUtils.meshGrid(DatasetFactory.createRange(9, Dataset.FLOAT64),
+    	@SuppressWarnings("deprecation")
+		List<Dataset> mg = DatasetUtils.meshGrid(DatasetFactory.createRange(9, Dataset.FLOAT64),
     			                                 DatasetFactory.createRange(6, Dataset.FLOAT64));
     	System.out.println("Created mesh grid of size "+mg.size());
     }
@@ -466,7 +470,8 @@ public class NumpyExamples {
      */
     @Test
     public void oGrid() {
-    	Dataset[] indexes = new Dataset[] {DatasetFactory.createRange(9, Dataset.FLOAT64),
+    	@SuppressWarnings("deprecation")
+		Dataset[] indexes = new Dataset[] {DatasetFactory.createRange(9, Dataset.FLOAT64),
                 DatasetFactory.createRange(6, Dataset.FLOAT64)};
     	List<Dataset> og = new ArrayList<Dataset>();
     	int rank = indexes.length;
@@ -543,7 +548,8 @@ public class NumpyExamples {
     @Test
     public void norm() {
     	
-    	Dataset oneD = DatasetFactory.createRange(100, Dataset.FLOAT);
+    	@SuppressWarnings("deprecation")
+		Dataset oneD = DatasetFactory.createRange(100, Dataset.FLOAT);
     	double vNorm = LinearAlgebra.norm(oneD);
     	System.out.println("Vector norm is "+vNorm);
     	

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/AbstractCompoundDatasetTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/AbstractCompoundDatasetTest.java
@@ -55,6 +55,7 @@ public class AbstractCompoundDatasetTest {
 		testSliceND(size, Dataset.INT16);
 	}
 
+	@SuppressWarnings("deprecation")
 	private void testSliceND(int isize, int size, int type) {
 		// 1D
 		CompoundDataset ta;
@@ -80,6 +81,7 @@ public class AbstractCompoundDatasetTest {
 		testSlicedDataset(ta);
 	}
 
+	@SuppressWarnings("deprecation")
 	private void testSliceND(int size, int type) {
 		// 1D
 		CompoundDataset ta;
@@ -470,6 +472,7 @@ public class AbstractCompoundDatasetTest {
 
 	@Test
 	public void testTake() {
+		@SuppressWarnings("deprecation")
 		Dataset a = DatasetFactory.createRange(12, Dataset.COMPLEX128);
 		Dataset t;
 		System.out.println(a);
@@ -502,6 +505,7 @@ public class AbstractCompoundDatasetTest {
 		System.out.println(t);
 	}
 
+	@SuppressWarnings("deprecation")
 	@Test
 	public void test1DErrors() {
 	
@@ -626,6 +630,7 @@ public class AbstractCompoundDatasetTest {
 		assertEquals(5.0, error3.getElements(4).getDouble(99), 0.001);
 	}
 
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testInternalErrors() {
 		Dataset[] aa =  new Dataset[5];
@@ -665,6 +670,7 @@ public class AbstractCompoundDatasetTest {
 		assertEquals(25.0, ae.getElements(4).getDouble(99), 0.001);
 	}
 
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testSlicing() {
 		CompoundDataset a;
@@ -677,6 +683,7 @@ public class AbstractCompoundDatasetTest {
 		assertArrayEquals(new int[] {-1, -2, -3}, a.getIntArray(2, 3));
 	}
 
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testBroadcastElements() {
 		CompoundDataset a;
@@ -713,6 +720,7 @@ public class AbstractCompoundDatasetTest {
 		assertEquals(0, b.getInt(4, 3));
 	}
 
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testBroadcastSliceView() {
 		Dataset a = DatasetFactory.createRange(3, 12, Dataset.INT32);

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/AbstractDatasetTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/AbstractDatasetTest.java
@@ -98,6 +98,7 @@ public class AbstractDatasetTest {
 		assertFalse("[2,1,4] and [2,4,3]", ShapeUtils.areShapesBroadcastCompatible(new int[] {2,1,4}, new int[] {2,4,3}));
 	}
 
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testMaxMin() {
 		Dataset a = DatasetFactory.createRange(12, Dataset.FLOAT64);
@@ -167,6 +168,7 @@ public class AbstractDatasetTest {
 	@Test
 	public void testGetSpeed() {
 		final int ITERATIONS = 1000;
+		@SuppressWarnings("deprecation")
 		Dataset a = DatasetFactory.createRange(1000000, Dataset.FLOAT64);
 		long start, startN, startP;
 
@@ -231,8 +233,10 @@ public class AbstractDatasetTest {
 
 	@Test
 	public void testHash() {
+		@SuppressWarnings("deprecation")
 		Dataset a = DatasetFactory.createRange(12, Dataset.FLOAT64);
 		a.setShape(3,4);
+		@SuppressWarnings("deprecation")
 		Dataset b = DatasetFactory.createRange(12, Dataset.FLOAT64);
 		b.setShape(3,4);
 
@@ -270,6 +274,7 @@ public class AbstractDatasetTest {
 		return true;
 	}
 
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testMaxSpeed() {
 		long start;
@@ -307,6 +312,7 @@ public class AbstractDatasetTest {
 		System.out.printf("Max short calculation took %g ms\n", elapsed*1e-6/ITERATIONS);
 	}
 
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testSort() {
 		Dataset a = DatasetFactory.createRange(12, Dataset.FLOAT64);
@@ -352,6 +358,7 @@ public class AbstractDatasetTest {
 		assertEquals("Second element", 10, b.getInt(1));
 	}
 
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testPut() {
 		Dataset d1 = DatasetFactory.createRange(6, Dataset.FLOAT64);
@@ -372,6 +379,7 @@ public class AbstractDatasetTest {
 
 	@Test
 	public void testTake() {
+		@SuppressWarnings("deprecation")
 		Dataset a = DatasetFactory.createRange(12, Dataset.FLOAT64);
 		Dataset t;
 
@@ -411,6 +419,7 @@ public class AbstractDatasetTest {
 	 */
 	@Test
 	public void testSqueeze() {
+		@SuppressWarnings("deprecation")
 		Dataset ds = DatasetFactory.createRange(10, Dataset.FLOAT64);
 		ds.setShape(2,1,5);
 
@@ -474,6 +483,7 @@ public class AbstractDatasetTest {
 	/**
 	 * Tests for tile method
 	 */
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testTile() {
 		// 1D
@@ -555,6 +565,7 @@ public class AbstractDatasetTest {
 	}
 
 	private void runTile(final int srows, final int scols, final int rows, final int cols) {
+		@SuppressWarnings("deprecation")
 		Dataset a = DatasetFactory.createRange(srows*scols, Dataset.FLOAT64).reshape(srows, scols);
 
 		long start, end;
@@ -602,6 +613,7 @@ public class AbstractDatasetTest {
 	/**
 	 * Tests for transpose method
 	 */
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testTranspose() {
 		// 2D
@@ -704,6 +716,7 @@ public class AbstractDatasetTest {
 	@Test
 	public void testRepeat() {
 		// 2D
+		@SuppressWarnings("deprecation")
 		Dataset ds = DatasetFactory.createRange(6, Dataset.FLOAT64);
 		ds.setShape(2,3);
 
@@ -798,6 +811,7 @@ public class AbstractDatasetTest {
 	@Test
 	public void testResize() {
 		int size = 6;
+		@SuppressWarnings("deprecation")
 		Dataset ds = DatasetFactory.createRange(size, Dataset.FLOAT64);
 		Dataset tf;
 		IndexIterator it;
@@ -883,6 +897,7 @@ public class AbstractDatasetTest {
 	
 	@Test
 	public void testView() {
+		@SuppressWarnings("deprecation")
 		Dataset a = DatasetFactory.createRange(60, Dataset.FLOAT64);
 		Dataset b = a.getView(true);
 		assertEquals(true, a.equals(b));
@@ -901,6 +916,7 @@ public class AbstractDatasetTest {
 	/**
 	 * Test equals and hashCode
 	 */
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testEquals() {
 		Dataset a, b, c, d, e;
@@ -938,6 +954,7 @@ public class AbstractDatasetTest {
 
 	@Test
 	public void testPrint() {
+		@SuppressWarnings("deprecation")
 		Dataset a = DatasetFactory.createRange(1000000, Dataset.INT32);
 
 		System.out.println(a);
@@ -948,6 +965,7 @@ public class AbstractDatasetTest {
 
 //		System.out.println(a.reshape(10, 10, 100, 100));
 
+		@SuppressWarnings("deprecation")
 		Dataset b = DatasetFactory.createRange(12, Dataset.INT32);
 
 		System.out.println(b);
@@ -959,6 +977,7 @@ public class AbstractDatasetTest {
 
 	@Test
 	public void testSlicing() {
+		@SuppressWarnings("deprecation")
 		Dataset a = DatasetFactory.createRange(1000, Dataset.INT32);
 		Dataset s, t;
 		IndexIterator is, it;
@@ -1088,6 +1107,7 @@ public class AbstractDatasetTest {
 		}
 	}
 
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testSlicingViews() {
 		Dataset a, b, c;
@@ -1212,6 +1232,7 @@ public class AbstractDatasetTest {
 		assertEquals(":,:", s);
 	}
 
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testSetSlice() {
 		Dataset a = DatasetFactory.createRange(100, Dataset.FLOAT64).reshape(20, 5);
@@ -1260,6 +1281,7 @@ public class AbstractDatasetTest {
 	public void test1DErrors() {
 		
 		// test 1D errors for single value
+		@SuppressWarnings("deprecation")
 		Dataset a = DatasetFactory.createRange(100, Dataset.INT32);
 		a.setErrors(5);
 		
@@ -1310,6 +1332,7 @@ public class AbstractDatasetTest {
 	public void test2DErrors() {
 		
 		// test 1D errors for single value
+		@SuppressWarnings("deprecation")
 		Dataset a = DatasetFactory.zeros(new int[] {100,100}, Dataset.INT32);
 		a.setErrors(5);
 		
@@ -1358,7 +1381,9 @@ public class AbstractDatasetTest {
 	@Test
 	public void testErrors() {
 		// test errors when reshaped and sliced
+		@SuppressWarnings("deprecation")
 		Dataset a = DatasetFactory.createRange(12, Dataset.INT32).reshape(4, 3);
+		@SuppressWarnings("deprecation")
 		Dataset e = DatasetFactory.createRange(12, Dataset.FLOAT64).reshape(4, 3);
 
 		a.setErrors(e);
@@ -1377,7 +1402,9 @@ public class AbstractDatasetTest {
 	@Test
 	public void testSetErrorBuffer() {
 		
+		@SuppressWarnings("deprecation")
 		Dataset a = DatasetFactory.zeros(new int[] {100,100}, Dataset.INT32);
+		@SuppressWarnings("deprecation")
 		Dataset err = DatasetFactory.createLinearSpace(0, a.getSize() - 1, a.getSize(), Dataset.FLOAT64);
 		err.setShape(a.getShape());
 		
@@ -1437,6 +1464,7 @@ public class AbstractDatasetTest {
 	public void testInternalErrors() {
 		
 		// test 1D errors for single value
+		@SuppressWarnings("deprecation")
 		Dataset a = DatasetFactory.createRange(100, Dataset.INT32);
 		a.setErrors(5);
 		
@@ -1456,6 +1484,7 @@ public class AbstractDatasetTest {
 		assertEquals(100.0, ae.getDouble(99), 0.001);	
 	}
 
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testZeroRankDatasets() {
 		Dataset a;
@@ -1498,6 +1527,7 @@ public class AbstractDatasetTest {
 		assertFalse("Differs", a.equals(DatasetFactory.createFromObject(2.f)));
 	}
 
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testConcatenate() {
 		Dataset a, b, c, d;
@@ -1532,6 +1562,7 @@ public class AbstractDatasetTest {
 		assertTrue("Dataset", c.equals(d));
 	}
 
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testSum() {
 		Dataset a = DatasetFactory.createRange(1024*1024, Dataset.INT32);
@@ -1595,6 +1626,7 @@ public class AbstractDatasetTest {
 
 	@Test
 	public void testRoll() {
+		@SuppressWarnings("deprecation")
 		Dataset a = DatasetFactory.createRange(10, Dataset.INT32);
 
 		Dataset r = DatasetUtils.roll(a, 2, null);
@@ -1617,6 +1649,7 @@ public class AbstractDatasetTest {
 
 	@Test
 	public void testRollAxis() {
+		@SuppressWarnings("deprecation")
 		Dataset a = DatasetFactory.ones(new int[] {3, 4, 5, 6}, Dataset.INT8);
 		Assert.assertArrayEquals(new int[] {3, 6, 4, 5}, DatasetUtils.rollAxis(a, 3, 1).getShape());
 		Assert.assertArrayEquals(new int[] {5, 3, 4, 6}, DatasetUtils.rollAxis(a, 2, 0).getShape());
@@ -1626,6 +1659,7 @@ public class AbstractDatasetTest {
 	@Test
 	public void testFindOccurrences() {
 		Dataset a = DatasetFactory.createFromObject(new double[] {0, 0, 3, 7, -4, 2, 1});
+		@SuppressWarnings("deprecation")
 		Dataset v = DatasetFactory.createRange(-3, 3, 1, Dataset.FLOAT64);
 
 		Dataset indexes = DatasetUtils.findFirstOccurrences(a, v);
@@ -1635,6 +1669,7 @@ public class AbstractDatasetTest {
 	@Test
 	public void testFindIndexes() {
 		Dataset a = DatasetFactory.createFromObject(new double[] {0, 0, 3, 7, -4, 2, 1});
+		@SuppressWarnings("deprecation")
 		Dataset v = DatasetFactory.createRange(-3, 3, 1, Dataset.FLOAT64);
 
 		IntegerDataset indexes = DatasetUtils.findIndexesForValues(a, v);
@@ -1801,6 +1836,7 @@ public class AbstractDatasetTest {
 
 	@Test
 	public void testFill() {
+		@SuppressWarnings("deprecation")
 		Dataset a = DatasetFactory.createRange(12, Dataset.FLOAT64);
 
 		Dataset b = DatasetFactory.zeros(a);
@@ -1899,6 +1935,7 @@ public class AbstractDatasetTest {
 
 	@Test
 	public void testSetByBoolean() {
+		@SuppressWarnings("deprecation")
 		Dataset a = DatasetFactory.createRange(10, Dataset.INT32);
 		a.max();
 		a.setByBoolean(0, Comparisons.greaterThan(a, 5));
@@ -1907,6 +1944,7 @@ public class AbstractDatasetTest {
 
 	@Test
 	public void testExtract() {
+		@SuppressWarnings("deprecation")
 		Dataset a = DatasetFactory.createRange(20, Dataset.INT32).reshape(4,5);
 		Dataset b = DatasetFactory.createFromObject(new boolean[] {true, false, true, false, false});
 
@@ -1916,12 +1954,14 @@ public class AbstractDatasetTest {
 
 	@Test
 	public void testSetBy1DIndex() {
+		@SuppressWarnings("deprecation")
 		Dataset a = DatasetFactory.createRange(10, Dataset.INT32);
 		a.max();
 		a.setBy1DIndex(0, Comparisons.nonZero(Comparisons.greaterThan(a, 5)).get(0));
 		Assert.assertEquals(a.max().longValue(), 5);
 	}
 
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testSetByPosition() {
 		Dataset a = DatasetFactory.createRange(10, Dataset.INT32);
@@ -1939,6 +1979,7 @@ public class AbstractDatasetTest {
 
 	@Test
 	public void testReshape() {
+		@SuppressWarnings("deprecation")
 		Dataset a = DatasetFactory.createRange(60, Dataset.INT32);
 		Dataset b = a.getSliceView(new int[] {1}, null, new int[] {2});
 		Dataset c = a.getSlice(new int[] {1}, null, new int[] {2});
@@ -1986,6 +2027,7 @@ public class AbstractDatasetTest {
 
 	@Test
 	public void testBroadcast() {
+		@SuppressWarnings("deprecation")
 		Dataset a = DatasetFactory.createRange(3, Dataset.INT32);
 		Dataset b = checkBroadcast2D(a, false, 2, 3);
 		Assert.assertEquals(1, b.getInt(0, 1));
@@ -2021,6 +2063,7 @@ public class AbstractDatasetTest {
 		return b;
 	}
 
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testBroadcastSliceView() {
 		Dataset a = DatasetFactory.createRange(12, Dataset.INT32);

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/AggregateDatasetTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/AggregateDatasetTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 public class AggregateDatasetTest {
 	ILazyDataset[] datasets;
 
+	@SuppressWarnings("deprecation")
 	@Before
 	public void init() {
 		datasets = new ILazyDataset[] {
@@ -38,6 +39,7 @@ public class AggregateDatasetTest {
 		};
 	}
 
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testConstructorFailures() {
 		@SuppressWarnings("unused")
@@ -121,6 +123,7 @@ public class AggregateDatasetTest {
 
 	@Test
 	public void testRepeatedDataset() throws Exception {
+		@SuppressWarnings("deprecation")
 		Dataset a = DatasetFactory.createRange(3, Dataset.FLOAT64);
 		Dataset[] as = new Dataset[5];
 		Arrays.fill(as, a);

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/BroadcastIteratorTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/BroadcastIteratorTest.java
@@ -76,6 +76,7 @@ public class BroadcastIteratorTest {
 		Assert.assertArrayEquals("Broadcasting " + msg, answer, result);
 	}
 
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testBroadcastWithNoOutput() {
 		Dataset a, b, c;
@@ -169,6 +170,7 @@ public class BroadcastIteratorTest {
 
 	}
 
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testBroadcastWithOutput() {
 		Dataset a, b, c;

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/BroadcastUtilsTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/BroadcastUtilsTest.java
@@ -24,6 +24,7 @@ public class BroadcastUtilsTest {
 		int[] mShape = new int[] {2,3};
 
 		int[] shape = new int[] {3};
+		@SuppressWarnings("deprecation")
 		Dataset view = DatasetFactory.zeros(shape, Dataset.INT8);
 		List<int[]> nShapes = BroadcastUtils.broadcastShapesToMax(mShape, shape);
 		view.setShape(nShapes.get(0));

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/ByteDatasetTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/ByteDatasetTest.java
@@ -43,6 +43,7 @@ public class ByteDatasetTest {
 
 	@Test
 	public void testStats() {
+		@SuppressWarnings("deprecation")
 		Dataset a = DatasetFactory.createRange(12, Dataset.INT8);
 		assertEquals(11., a.max().doubleValue(), 1e-6);
 		assertEquals(0., a.min().doubleValue(), 1e-6);

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/ComparisonsTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/ComparisonsTest.java
@@ -216,6 +216,7 @@ public class ComparisonsTest {
 		Dataset c = DatasetFactory.createFromObject(new byte[] { 0, 0, 0, 0, 0, 0 }).reshape(2, 3);
 		List<IntegerDataset> e = Comparisons.nonZero(c);
 		Assert.assertEquals(e.size(), 2);
+		@SuppressWarnings("deprecation")
 		Dataset empty = DatasetFactory.createFromList(Dataset.INT32, new ArrayList<Integer>());
 		TestUtils.assertDatasetEquals(e.get(0), empty);
 		TestUtils.assertDatasetEquals(e.get(1), empty);
@@ -393,6 +394,7 @@ public class ComparisonsTest {
 		Assert.assertFalse(Comparisons.isMonotonic(x, Monotonicity.STRICTLY_DECREASING));
 		Assert.assertFalse(Comparisons.isMonotonic(x, Monotonicity.STRICTLY_INCREASING));
 
+		@SuppressWarnings("deprecation")
 		Dataset d = DatasetFactory.createRange(5, Dataset.INT32);
 		Assert.assertTrue(Comparisons.isMonotonic(d, Monotonicity.NONDECREASING));
 		Assert.assertTrue(Comparisons.isMonotonic(d, Monotonicity.STRICTLY_INCREASING));

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/ComplexDoubleDatasetTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/ComplexDoubleDatasetTest.java
@@ -100,6 +100,7 @@ public class ComplexDoubleDatasetTest {
 
 	@Test
 	public void testStats() {
+		@SuppressWarnings("deprecation")
 		Dataset a = DatasetFactory.createRange(12, Dataset.COMPLEX128);
 		assertEquals(5.5, ((Complex) a.mean()).getReal(), 1e-6);
 		assertEquals(0., ((Complex) a.mean()).getImaginary(), 1e-6);

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/DoubleDatasetTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/DoubleDatasetTest.java
@@ -196,6 +196,7 @@ public class DoubleDatasetTest {
 
 	@Test
 	public void testStats() {
+		@SuppressWarnings("deprecation")
 		Dataset a = DatasetFactory.createRange(12, Dataset.FLOAT64);
 		assertEquals(11., a.max().doubleValue(), 1e-6);
 		assertEquals(0., a.min().doubleValue(), 1e-6);
@@ -258,6 +259,7 @@ public class DoubleDatasetTest {
 		assertEquals(6, a.maxPos()[0]);
 		assertEquals(0, a.minPos()[0]);
 
+		@SuppressWarnings("deprecation")
 		Dataset b = DatasetFactory.zeros(new int[] { 100, 200 }, Dataset.FLOAT64);
 
 		b.set(100.00, new int[] { 50, 100 });
@@ -276,6 +278,7 @@ public class DoubleDatasetTest {
 		assertEquals(50, b.maxPos(true)[0]);
 		assertEquals(100, b.maxPos(true)[1]);
 
+		@SuppressWarnings("deprecation")
 		Dataset c = DatasetFactory.zeros(new int[] { 100, 200 }, Dataset.FLOAT64);
 		c.set(100.00, new int[] { 99, 50 });
 		c.set(99.99, new int[] { 50, 50 });

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/FloatDatasetTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/FloatDatasetTest.java
@@ -43,6 +43,7 @@ public class FloatDatasetTest {
 
 	@Test
 	public void testStats() {
+		@SuppressWarnings("deprecation")
 		Dataset a = DatasetFactory.createRange(12, Dataset.FLOAT32);
 		assertEquals(11., a.max().doubleValue(), 1e-6);
 		assertEquals(0., a.min().doubleValue(), 1e-6);

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/IndexIteratorTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/IndexIteratorTest.java
@@ -43,6 +43,7 @@ public class IndexIteratorTest {
 		testIterationsND(size, type);
 	}
 
+	@SuppressWarnings("deprecation")
 	private void testIterationsND(int size, int type) {
 		Dataset ta;
 
@@ -107,6 +108,7 @@ public class IndexIteratorTest {
 		int rank = shape.length;
 		int[] lstart = siter.getStart();
 		int[] lstep = siter.getStep();
+		@SuppressWarnings("deprecation")
 		Dataset result = DatasetFactory.zeros(shape, Dataset.FLOAT64);
 
 		// set up the vectors needed to do this
@@ -217,6 +219,7 @@ public class IndexIteratorTest {
 		testSliceIterationND(size, type);
 	}
 
+	@SuppressWarnings("deprecation")
 	private void testSliceIterationND(int size, int type) {
 		Dataset ta;
 

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/IntegerDatasetTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/IntegerDatasetTest.java
@@ -44,6 +44,7 @@ public class IntegerDatasetTest {
 
 	@Test
 	public void testStats() {
+		@SuppressWarnings("deprecation")
 		Dataset a = DatasetFactory.createRange(12, Dataset.INT32);
 		assertEquals(11., a.max().doubleValue(), 1e-6);
 		assertEquals(0., a.min().doubleValue(), 1e-6);
@@ -60,6 +61,7 @@ public class IntegerDatasetTest {
 		assertEquals(6,a.maxPos()[0]);
 		assertEquals(0,a.minPos()[0]);
 		
+		@SuppressWarnings("deprecation")
 		Dataset b = DatasetFactory.zeros(new int[]{100,200}, Dataset.INT32 );
 		
 		b.set(100, new int[]{50,100});

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/InterpolatorUtilsTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/InterpolatorUtilsTest.java
@@ -22,11 +22,15 @@ public class InterpolatorUtilsTest {
 	@Test
 	public void test() {
 		
+		@SuppressWarnings("deprecation")
 		Dataset im = DatasetFactory.createRange(0.0,10000.0,1.0, Dataset.FLOAT32);
 		im = im.reshape(100,100);
+		@SuppressWarnings("deprecation")
 		Dataset off = Maths.sin(DatasetFactory.createRange(0.0, 10.0, 0.1,Dataset.FLOAT32));
+		@SuppressWarnings("deprecation")
 		Dataset axis = DatasetFactory.createRange(-5.0, 5.0, 0.1, Dataset.FLOAT32);
 		
+		@SuppressWarnings("deprecation")
 		Dataset newaxis = DatasetFactory.createRange(-10.0, 10.0, 0.1, Dataset.FLOAT32);
 		
 		Dataset output = InterpolatorUtils.remapOneAxis(im, 0, off, axis, newaxis);

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/LazyDynamicLoaderTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/LazyDynamicLoaderTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 
 public class LazyDynamicLoaderTest {
 	
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testLoader() throws Exception {
 		
@@ -64,11 +65,14 @@ public class LazyDynamicLoaderTest {
 		
 		int[] maxShape = new int[]{10,13,20,20};
 		
+		@SuppressWarnings("deprecation")
 		Dataset range = DatasetFactory.createRange(10*13*20*20,Dataset.INT64);
 		range.setShape(maxShape);
 		
 		LazyDynamicDataset dataset = getDataset(range,2,"data");
+		@SuppressWarnings("deprecation")
 		LazyDynamicDataset ax1 = getDataset(DatasetFactory.createRange(10, Dataset.INT64),0,"ax0");
+		@SuppressWarnings("deprecation")
 		LazyDynamicDataset ax2 = getDataset(DatasetFactory.createRange(13, Dataset.INT64),0,"ax1");
 		
 		AxesMetadata ax = MetadataFactory.createMetadata(AxesMetadata.class, 4);

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/LazyMathsTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/LazyMathsTest.java
@@ -20,6 +20,7 @@ public class LazyMathsTest {
 
 	@Test
 	public void testSum() throws Exception {
+		@SuppressWarnings("deprecation")
 		Dataset a = DatasetFactory.createRange(100, Dataset.FLOAT64);
 
 		TestUtils.assertDatasetEquals(a.sum(0), LazyMaths.sum(a, 0), 1e-9, 1e-15);
@@ -42,6 +43,7 @@ public class LazyMathsTest {
 
 	@Test
 	public void testSumIgnoreAxes() throws Exception {
+		@SuppressWarnings("deprecation")
 		Dataset a = DatasetFactory.createRange(100, Dataset.FLOAT64);
 
 		a.setShape(10, 10);
@@ -68,6 +70,7 @@ public class LazyMathsTest {
 
 	@Test
 	public void testProduct() throws Exception {
+		@SuppressWarnings("deprecation")
 		Dataset a = DatasetFactory.createRange(100, Dataset.FLOAT64);
 		a.iadd(1.);
 		a.idivide(100.);
@@ -93,6 +96,7 @@ public class LazyMathsTest {
 	@Test
 	public void testMeanIgnore() throws Exception {
 
+		@SuppressWarnings("deprecation")
 		Dataset a = DatasetFactory.createRange(100, Dataset.FLOAT64);
 		a.setShape(10, 10);
 		TestUtils.assertDatasetEquals(a.mean(1), LazyMaths.mean(a, 0), 1e-9, 1e-15);
@@ -109,6 +113,7 @@ public class LazyMathsTest {
 		TestUtils.assertDatasetEquals(a.mean(3).squeeze(),LazyMaths.mean(a, 0,1,2), 1e-9, 1e-15);
 		TestUtils.assertDatasetEquals(a.mean(0).mean(0).squeeze(),LazyMaths.mean(a, 2,3), 1e-9, 1e-15);
 		
+		@SuppressWarnings("deprecation")
 		Dataset er = DatasetFactory.createRange(100, Dataset.FLOAT64);
 		a.setShape(10, 10);
 		er.setShape(10, 10);

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/LazyWriteableDatasetTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/LazyWriteableDatasetTest.java
@@ -27,6 +27,7 @@ public class LazyWriteableDatasetTest {
 		LazyWriteableDataset ld = LazyWriteableDataset.createLazyDataset(d);
 
 		SliceND s = new SliceND(d.getShapeRef(), (Slice) null, null, new Slice(1), new Slice(0, null, 2));
+		@SuppressWarnings("deprecation")
 		Dataset sd = DatasetFactory.ones(s.getShape(), d.getDType());
 		ld.setSlice(sd, s);
 		Assert.assertEquals(d.getSlice(s), sd);
@@ -40,6 +41,7 @@ public class LazyWriteableDatasetTest {
 		LazyWriteableDataset ld = old.getSliceView();
 
 		SliceND s = new SliceND(ld.getShape(), (Slice) null, null, new Slice(1, null), new Slice(0, null, 2));
+		@SuppressWarnings("deprecation")
 		Dataset sd = DatasetFactory.ones(s.getShape(), ld.getDType());
 		ld.setSlice(sd, s);
 		Assert.assertEquals(d.getSlice(s), sd);
@@ -53,6 +55,7 @@ public class LazyWriteableDatasetTest {
 		LazyWriteableDataset ld = old.getSliceView(null, null, null, new Slice(1, null));
 
 		SliceND s = new SliceND(ld.getShape(), (Slice) null, null, new Slice(1, null), new Slice(0, null, 2));
+		@SuppressWarnings("deprecation")
 		Dataset sd = DatasetFactory.ones(s.getShape(), ld.getDType());
 		ld.setSlice(sd, s);
 		Assert.assertEquals(d.getSlice((Slice) null, null, new Slice(1, null), new Slice(1, null, 2)), sd);
@@ -66,6 +69,7 @@ public class LazyWriteableDatasetTest {
 		LazyWriteableDataset ld = old.getTransposedView();
 		
 		SliceND s = new SliceND(ld.getShape(), new Slice(0, null, 2), new Slice(1, null), null, null);
+		@SuppressWarnings("deprecation")
 		Dataset sd = DatasetFactory.ones(s.getShape(), ld.getDType());
 		ld.setSlice(sd, s);
 		Assert.assertEquals(d.transpose().getSlice(s), sd);
@@ -78,6 +82,7 @@ public class LazyWriteableDatasetTest {
 		LazyWriteableDataset ld = LazyWriteableDataset.createLazyDataset(d, new int[] {2, 2, 3, 4});
 
 		SliceND s = new SliceND(d.getShapeRef(), ld.getMaxShape(), new Slice(1,2), null, new Slice(1), new Slice(0, null, 2));
+		@SuppressWarnings("deprecation")
 		Dataset sd = DatasetFactory.ones(s.getShape(), d.getDType());
 		ld.setSlice(sd, s);
 		Assert.assertEquals(ld.getSlice(s), sd);

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/LinearAlgebraTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/LinearAlgebraTest.java
@@ -32,6 +32,7 @@ public class LinearAlgebraTest {
 		return x == 0 ? Math.abs(b) < 10e-6 : Math.abs(x - b) < 10e-6*x;
 	}
 
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testTensorDot() {
 		Dataset a = DatasetFactory.createRange(60, Dataset.FLOAT32).reshape(3, 4, 5);
@@ -68,7 +69,9 @@ public class LinearAlgebraTest {
 
 	@Test
 	public void testDot() {
+		@SuppressWarnings("deprecation")
 		Dataset a = DatasetFactory.createRange(10, Dataset.FLOAT32);
+		@SuppressWarnings("deprecation")
 		Dataset b = DatasetFactory.createRange(-6, 4, 1, Dataset.INT16);
 
 		long start;
@@ -180,6 +183,7 @@ public class LinearAlgebraTest {
 		TestUtils.assertDatasetEquals(Maths.negative(c), d, 1e-15, 1e-15);
 	}
 
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testNorm() {
 		Dataset a, b;
@@ -219,10 +223,12 @@ public class LinearAlgebraTest {
 
 	@Test
 	public void testDeterminant() {
+		@SuppressWarnings("deprecation")
 		Dataset a = DatasetFactory.createRange(1, 21, 1, Dataset.INT32).reshape(4, 5);
 		assertEquals(0, LinearAlgebra.calcDeterminant(a.getSliceView(null, new Slice(4))), 1e-8);
 	}
 
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testTrace() {
 		Dataset a = DatasetFactory.createRange(20, Dataset.INT32).reshape(4, 5);
@@ -234,6 +240,7 @@ public class LinearAlgebraTest {
 		TestUtils.assertDatasetEquals(DatasetFactory.createFromObject(new int[]{36, 116, 196}, null), LinearAlgebra.trace(a, 0, 1, 2), true, 1e-12, 1e-12);
 	}
 
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testKronecker() {
 		Dataset a = DatasetFactory.createFromObject(Dataset.INT32, new int[] {1, 10, 100});
@@ -247,6 +254,7 @@ public class LinearAlgebraTest {
 		TestUtils.assertDatasetEquals(DatasetFactory.createFromObject(new float[]{1, 1, 0, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 0, 1, 1}, 4, 4), LinearAlgebra.kroneckerProduct(a, b), true, 1e-12, 1e-12);
 	}
 
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testPower() {
 		Dataset a = DatasetFactory.createFromObject(new int[] {0, 1, -1, 0}, 2, 2);

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/LongDatasetTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/LongDatasetTest.java
@@ -67,6 +67,7 @@ public class LongDatasetTest {
 
 	@Test
 	public void testStats() {
+		@SuppressWarnings("deprecation")
 		Dataset a = DatasetFactory.createRange(12, Dataset.INT64);
 		assertEquals(11., a.max().doubleValue(), 1e-6);
 		assertEquals(0., a.min().doubleValue(), 1e-6);

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/MathsTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/MathsTest.java
@@ -1675,6 +1675,7 @@ public class MathsTest {
 		checkDatasets(null, null, d, ta);
 	}
 
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testGradient() {
 		double[] data = {1, 2, 4, 7, 11, 16};
@@ -1816,6 +1817,7 @@ public class MathsTest {
 		Assert.assertEquals((1 - t) * f1 + t * f2, v, 1e-15);
 	}
 
+	@SuppressWarnings("deprecation")
 	private void checkInterpolate2(Dataset a, double x) {
 		int s = a.getShapeRef()[0];
 		Dataset xa = DatasetFactory.createRange(s, Dataset.FLOAT64);
@@ -1871,6 +1873,7 @@ public class MathsTest {
 
 	private void checkInterpolate3(Dataset a, double x) {
 		int s = a.getShapeRef()[0];
+		@SuppressWarnings("deprecation")
 		Dataset dv = Maths.interpolate(DatasetFactory.createRange(s, Dataset.INT32), a, DatasetFactory.createFromObject(x), 0, 0);
 		double v = dv.getElementDoubleAbs(0);
 		if (x <= -1 || x >= s) {
@@ -2031,6 +2034,7 @@ public class MathsTest {
 
 	@Test
 	public void testLinearInterpolation() {
+		@SuppressWarnings("deprecation")
 		Dataset xa = DatasetFactory.createRange(60, Dataset.INT32);
 		xa.iadd(1);
 
@@ -2043,6 +2047,7 @@ public class MathsTest {
 			checkInterpolate3(xa, x);
 		}
 
+		@SuppressWarnings("deprecation")
 		Dataset xb = DatasetFactory.createRange(120, Dataset.INT32);
 		xb.setShape(60, 2);
 		xb.ifloorDivide(2);
@@ -2084,7 +2089,9 @@ public class MathsTest {
 
 	@Test
 	public void testBitwise() {
+		@SuppressWarnings("deprecation")
 		Dataset xa = DatasetFactory.createRange(-4, 4, 1, Dataset.INT8);
+		@SuppressWarnings("deprecation")
 		Dataset xb = DatasetFactory.createRange(8, Dataset.INT8);
 
 		TestUtils.assertDatasetEquals(DatasetFactory.createFromObject(new byte[] {0, 1, 2, 3, 0, 1, 2, 3}),
@@ -2125,6 +2132,7 @@ public class MathsTest {
 
 	@Test
 	public void testDivideTowardsFloor() {
+		@SuppressWarnings("deprecation")
 		Dataset xa = DatasetFactory.createRange(-4, 4, 1, Dataset.INT8);
 		TestUtils.assertDatasetEquals(DatasetFactory.createFromObject(new byte[] {-2, -2, -1, -1,  0,  0,  1,  1}),
 				Maths.divideTowardsFloor(xa, 2), true, ABSERRD, ABSERRD);
@@ -2141,6 +2149,7 @@ public class MathsTest {
 
 	@Test
 	public void testFloorDivide() {
+		@SuppressWarnings("deprecation")
 		Dataset xa = DatasetFactory.createRange(-4, 4, 1, Dataset.INT8);
 		TestUtils.assertDatasetEquals(DatasetFactory.createFromObject(new byte[] {-2, -2, -1, -1,  0,  0,  1,  1}),
 				Maths.floorDivide(xa, 2), true, ABSERRD, ABSERRD);
@@ -2157,6 +2166,7 @@ public class MathsTest {
 
 	@Test
 	public void testFloorRemainder() {
+		@SuppressWarnings("deprecation")
 		Dataset xa = DatasetFactory.createRange(-4, 4, 1, Dataset.INT8);
 		TestUtils.assertDatasetEquals(DatasetFactory.createFromObject(new byte[] {0, 1, 0, 1, 0, 1, 0, 1}),
 				Maths.floorRemainder(xa, 2), true, ABSERRD, ABSERRD);

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/PositionIteratorTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/PositionIteratorTest.java
@@ -43,6 +43,7 @@ public class PositionIteratorTest {
 		int size = 3 * 3 * 1024 * 1024;
 		int type = Dataset.FLOAT64;
 		
+		@SuppressWarnings("deprecation")
 		Dataset ta = DatasetFactory.createRange(0, size, 1, type).reshape(3, 3, 1024, 1024);
 		
 		int[] start = new int[] {1,1,0,0};
@@ -52,6 +53,7 @@ public class PositionIteratorTest {
 		testDatasetAxes(ta, axes, start, stop, step);
 	}
 
+	@SuppressWarnings("deprecation")
 	private void testIterationND(int size, int type) {
 		Dataset ta;
 

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/RGBDatasetTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/RGBDatasetTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
  * Basic tests of RGB dataset
  */
 public class RGBDatasetTest {
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testConstructors() {
 		int n = 250;

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/ShortDatasetTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/ShortDatasetTest.java
@@ -43,6 +43,7 @@ public class ShortDatasetTest {
 
 	@Test
 	public void testStats() {
+		@SuppressWarnings("deprecation")
 		Dataset a = DatasetFactory.createRange(12, Dataset.INT16);
 		assertEquals(11., a.max().doubleValue(), 1e-6);
 		assertEquals(0., a.min().doubleValue(), 1e-6);

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/SingleInputBroadcastIteratorTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/SingleInputBroadcastIteratorTest.java
@@ -19,6 +19,7 @@ import org.junit.Test;
 
 public class SingleInputBroadcastIteratorTest {
 
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testBroadcastWithNoOutput() {
 		Dataset a, b, c;
@@ -62,6 +63,7 @@ public class SingleInputBroadcastIteratorTest {
 		}
 	}
 
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testBroadcastWithOutput() {
 		Dataset a, c;

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/SliceIteratorTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/SliceIteratorTest.java
@@ -38,6 +38,7 @@ public class SliceIteratorTest {
 		testIterationsND(size, type);
 	}
 
+	@SuppressWarnings("deprecation")
 	private void testIterationsND(int size, int type) {
 		Dataset ta;
 

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/StatsTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/StatsTest.java
@@ -135,6 +135,7 @@ public class StatsTest {
 
 	@Test
 	public void testNaNs() {
+		@SuppressWarnings("deprecation")
 		Dataset a = DatasetFactory.createRange(1, 7, 1, Dataset.FLOAT64);
 
 		assertEquals("Sum", 21, ((Number) a.sum()).doubleValue(), 1e-6);
@@ -152,6 +153,7 @@ public class StatsTest {
 
 	@Test
 	public void testInfs() {
+		@SuppressWarnings("deprecation")
 		Dataset a = DatasetFactory.createRange(1, 7, 1, Dataset.FLOAT64);
 
 		assertEquals("Sum", 21, ((Number) a.sum()).doubleValue(), 1e-6);
@@ -242,6 +244,7 @@ public class StatsTest {
 
 	@Test
 	public void testOutlierValues() {
+		@SuppressWarnings("deprecation")
 		Dataset a = DatasetFactory.zeros(new int[] {20}, Dataset.FLOAT64);
 
 		double[] o = Stats.outlierValues(a, 0.01, 99.9, 10);

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/StrideIteratorTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/StrideIteratorTest.java
@@ -44,6 +44,7 @@ public class StrideIteratorTest {
 		testIterationsND(size, type);
 	}
 
+	@SuppressWarnings("deprecation")
 	private void testIterationsND(int size, int type) {
 		Dataset ta;
 
@@ -114,6 +115,7 @@ public class StrideIteratorTest {
 		int rank = shape.length;
 		int[] lstart = siter.getStart();
 		int[] lstep = siter.getStep();
+		@SuppressWarnings("deprecation")
 		Dataset result = DatasetFactory.zeros(shape, Dataset.FLOAT64);
 
 		// set up the vectors needed to do this
@@ -186,6 +188,7 @@ public class StrideIteratorTest {
 	private Dataset newSlice(Dataset t, int[] start, int[] stop, int[] step) {
 		StrideIterator iter = new StrideIterator(t.getElementsPerItem(), t.getShape(), start, stop, step);
 
+		@SuppressWarnings("deprecation")
 		Dataset result = DatasetFactory.zeros(iter.getShape(), Dataset.FLOAT64);
 		int i = 0;
 		while (iter.hasNext()) {
@@ -292,6 +295,7 @@ public class StrideIteratorTest {
 
 	@Test
 	public void testNegativeStrideIteration() {
+		@SuppressWarnings("deprecation")
 		Dataset t = DatasetFactory.createRange(40, Dataset.FLOAT);
 
 		SliceIterator siter = (SliceIterator) t.getSliceIterator(new int[] {12}, null, new int[] {-2});
@@ -324,6 +328,7 @@ public class StrideIteratorTest {
 		testSliceIterationND(size, type);
 	}
 
+	@SuppressWarnings("deprecation")
 	private void testSliceIterationND(int size, int type) {
 		Dataset ta;
 
@@ -451,6 +456,7 @@ public class StrideIteratorTest {
 		testSlicedDataset(ta, 2, 2, -3, 2);
 	}
 
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testBroadcastStrideIteration() {
 		Dataset b, r;

--- a/org.eclipse.january/src/org/eclipse/january/dataset/AbstractDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/AbstractDataset.java
@@ -445,6 +445,7 @@ public abstract class AbstractDataset extends LazyDatasetBase implements Dataset
 
 		final int length = ((Number) selection.sum()).intValue();
 		final int is = getElementsPerItem();
+		@SuppressWarnings("deprecation")
 		Dataset r = DatasetFactory.zeros(is, new int[] { length }, getDType());
 		BooleanIterator biter = getBooleanIterator(selection);
 
@@ -459,6 +460,7 @@ public abstract class AbstractDataset extends LazyDatasetBase implements Dataset
 	@Override
 	public Dataset getBy1DIndex(IntegerDataset index) {
 		final int is = getElementsPerItem();
+		@SuppressWarnings("deprecation")
 		final Dataset r = DatasetFactory.zeros(is, index.getShape(), getDType());
 		final IntegerIterator iter = new IntegerIterator(index, size, is);
 
@@ -474,6 +476,7 @@ public abstract class AbstractDataset extends LazyDatasetBase implements Dataset
 	public Dataset getByIndexes(final Object... indexes) {
 		final IntegersIterator iter = new IntegersIterator(shape, indexes);
 		final int is = getElementsPerItem();
+		@SuppressWarnings("deprecation")
 		final Dataset r = DatasetFactory.zeros(is, iter.getShape(), getDType());
 
 		final int[] pos = iter.getPos();
@@ -1463,6 +1466,7 @@ public abstract class AbstractDataset extends LazyDatasetBase implements Dataset
 	 */
 	abstract public AbstractDataset getSlice(final SliceIterator iterator);
 
+	@SuppressWarnings("deprecation")
 	@Override
 	public Dataset setSlice(final Object obj, final SliceND slice) {
 		Dataset ds;

--- a/org.eclipse.january/src/org/eclipse/january/dataset/BroadcastUtils.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/BroadcastUtils.java
@@ -162,6 +162,7 @@ public final class BroadcastUtils {
 		}
 	}
 
+	@SuppressWarnings("deprecation")
 	static Dataset createDataset(final Dataset a, final Dataset b, final int[] shape) {
 		final int rt;
 		final int ar = a.getRank();

--- a/org.eclipse.january/src/org/eclipse/january/dataset/Comparisons.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/Comparisons.java
@@ -1250,6 +1250,7 @@ public class Comparisons {
 	 * @param a
 	 * @return list of positions as integer datasets
 	 */
+	@SuppressWarnings("deprecation")
 	public static List<IntegerDataset> nonZero(Dataset a) {
 		final int rank = a.getRank();
 		final List<List<Integer>> indices = new ArrayList<List<Integer>>();

--- a/org.eclipse.january/src/org/eclipse/january/dataset/DatasetUtils.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/DatasetUtils.java
@@ -71,6 +71,7 @@ public class DatasetUtils {
 		nshape[axis] += bshape[axis];
 		final int ot = DTypeUtils.getDType(b);
 		final int dt = DTypeUtils.getDType(a);
+		@SuppressWarnings("deprecation")
 		Dataset ds = DatasetFactory.zeros(a.getElementsPerItem(), nshape, dt > ot ? dt : ot);
 		IndexIterator iter = ds.getIterator(true);
 		int[] pos = iter.getPos();
@@ -144,6 +145,7 @@ public class DatasetUtils {
 	 * @param axis if null, then use flattened view
 	 * @return a sub-array
 	 */
+	@SuppressWarnings("deprecation")
 	public static <T extends Dataset> T take(final T a, final int[] indices, Integer axis) {
 		if (indices == null || indices.length == 0) {
 			utilsLogger.error("No indices given");
@@ -234,6 +236,7 @@ public class DatasetUtils {
 			newShape[i] = shape[i]*reps[i];
 		}
 
+		@SuppressWarnings("deprecation")
 		Dataset tdata = DatasetFactory.zeros(a.getElementsPerItem(), newShape, DTypeUtils.getDType(a));
 
 		// decide which way to put slices
@@ -418,6 +421,7 @@ public class DatasetUtils {
 			ashape[axis] += as[i].getShape()[axis];
 		}
 
+		@SuppressWarnings("deprecation")
 		Dataset result = DatasetFactory.zeros(isize, ashape, at);
 
 		int[] start = new int[ashape.length];
@@ -468,6 +472,7 @@ public class DatasetUtils {
 	 * @param axis
 	 * @return list of split datasets
 	 */
+	@SuppressWarnings("deprecation")
 	public static List<Dataset> split(final Dataset a, int[] indices, final int axis) {
 		final int[] ashape = a.getShapeRef();
 		final int rank = ashape.length;
@@ -580,6 +585,7 @@ public class DatasetUtils {
 			newShape[axis] = nlen;
 		}
 
+		@SuppressWarnings("deprecation")
 		Dataset rdata = DatasetFactory.zeros(is, newShape, a.getDType());
 		Serializable nbuf = rdata.getBuffer();
 
@@ -627,6 +633,7 @@ public class DatasetUtils {
 	 */
 	public static <T extends Dataset> T resize(final T a, final int... shape) {
 		int size = a.getSize();
+		@SuppressWarnings("deprecation")
 		Dataset rdata = DatasetFactory.zeros(a.getElementsPerItem(), shape, a.getDType());
 		IndexIterator it = rdata.getIterator();
 		while (it.hasNext()) {
@@ -1099,6 +1106,7 @@ public class DatasetUtils {
 	 */
 	public static Dataset eye(final int rows, final int cols, final int offset, final int dtype) {
 		int[] shape = new int[] {rows, cols};
+		@SuppressWarnings("deprecation")
 		Dataset a = DatasetFactory.zeros(shape, dtype);
 
 		int[] pos = new int[] {0, offset};
@@ -1121,6 +1129,7 @@ public class DatasetUtils {
 	 * @param offset
 	 * @return diagonal matrix
 	 */
+	@SuppressWarnings("deprecation")
 	public static <T extends Dataset> T diag(final T a, final int offset) {
 		final int dtype = a.getDType();
 		final int rank = a.getRank();
@@ -1207,6 +1216,7 @@ public class DatasetUtils {
 			throw new IllegalArgumentException("Datasets with " + isize + " elements per item not supported");
 		}
 
+		@SuppressWarnings("deprecation")
 		final Dataset result = DatasetFactory.zeros(isize, data.getShape(), dtype);
 		result.setName(data.getName());
 
@@ -1542,6 +1552,7 @@ public class DatasetUtils {
 
 		for (int i = 0; i < rank; i++) {
 			Dataset axis = axes[i];
+			@SuppressWarnings("deprecation")
 			Dataset coord = DatasetFactory.zeros(nshape, axis.getDType());
 			result.add(coord);
 
@@ -2211,6 +2222,7 @@ public class DatasetUtils {
 		} else {
 			PositionIterator pi = a.getPositionIterator(axis);
 			int s = a.getShapeRef()[axis];
+			@SuppressWarnings("deprecation")
 			Dataset u = DatasetFactory.zeros(is, new int[] {s}, a.getDType());
 			Dataset v = DatasetFactory.zeros(u);
 			int[] pos = pi.getPos();
@@ -2360,6 +2372,7 @@ public class DatasetUtils {
 		int dt = DTypeUtils.getBestDType(dx.getDType(),dy.getDType());
 		int ds = Math.max(dx.getElementsPerItem(), dy.getElementsPerItem());
 
+		@SuppressWarnings("deprecation")
 		Dataset r = DatasetFactory.zeros(ds, condition.getShapeRef(), dt);
 		IndexIterator iter = condition.getIterator(true);
 		final int[] pos = iter.getPos();
@@ -2405,6 +2418,7 @@ public class DatasetUtils {
 			throw new IllegalArgumentException("Dataset types of choices are invalid");
 		}
 
+		@SuppressWarnings("deprecation")
 		Dataset r = DatasetFactory.zeros(ds, conditions[0].getShapeRef(), dt);
 		Dataset d = DatasetFactory.createFromObject(def).getBroadcastView(r.getShapeRef());
 		PositionIterator iter = new PositionIterator(r.getShapeRef());
@@ -2460,6 +2474,7 @@ public class DatasetUtils {
 		index = (IntegerDataset) dChoices[n];
 		dChoices[n] = null;
 
+		@SuppressWarnings("deprecation")
 		Dataset r = DatasetFactory.zeros(ds, index.getShape(), dt);
 		IndexIterator iter = index.getIterator(true);
 		final int[] pos = iter.getPos();
@@ -2597,6 +2612,7 @@ public class DatasetUtils {
 	 * @param condition should be broadcastable to data
 	 * @return 1-D dataset of values
 	 */
+	@SuppressWarnings("deprecation")
 	public static Dataset extract(final IDataset data, final IDataset condition) {
 		Dataset a = convertToDataset(data.getSliceView());
 		Dataset b = cast(condition.getSliceView(), Dataset.BOOL);

--- a/org.eclipse.january/src/org/eclipse/january/dataset/LazyDatasetBase.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/LazyDatasetBase.java
@@ -935,6 +935,7 @@ public abstract class LazyDatasetBase implements ILazyDataset, Serializable {
 		}
 	}
 
+	@SuppressWarnings("deprecation")
 	protected ILazyDataset createFromSerializable(Serializable blob, boolean keepLazy) {
 		ILazyDataset d = null;
 		if (blob instanceof ILazyDataset) {

--- a/org.eclipse.january/src/org/eclipse/january/dataset/LazyMaths.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/LazyMaths.java
@@ -174,6 +174,7 @@ public final class LazyMaths {
 		return mean(0, Integer.MAX_VALUE -1 , data, ignoreAxes);
 	}
 
+	@SuppressWarnings("deprecation")
 	private static Dataset prepareDataset(int axis, int[] shape, int[][] sliceInfo) {
 		int rank = shape.length;
 		if (axis < 0)

--- a/org.eclipse.january/src/org/eclipse/january/dataset/LazyWriteableDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/LazyWriteableDataset.java
@@ -123,6 +123,7 @@ public class LazyWriteableDataset extends LazyDynamicDataset implements ILazyWri
 				return d.getSlice(mon, slice);
 			}
 
+			@SuppressWarnings("deprecation")
 			@Override
 			public void setSlice(IMonitor mon, IDataset data, SliceND slice) throws IOException {
 				if (slice.isExpanded()) {

--- a/org.eclipse.january/src/org/eclipse/january/dataset/LinearAlgebra.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/LinearAlgebra.java
@@ -88,6 +88,7 @@ public class LinearAlgebra {
 				dshape[d++] = bshape[i];
 		}
 		int dtype = DTypeUtils.getBestDType(a.getDType(), b.getDType());
+		@SuppressWarnings("deprecation")
 		Dataset data = DatasetFactory.zeros(dshape, dtype);
 
 		SliceIterator ita = a.getSliceIteratorFromAxes(null, achoice);
@@ -173,6 +174,7 @@ public class LinearAlgebra {
 				dshape[d++] = bshape[i];
 		}
 		int dtype = DTypeUtils.getBestDType(a.getDType(), b.getDType());
+		@SuppressWarnings("deprecation")
 		Dataset data = DatasetFactory.zeros(dshape, dtype);
 
 		SliceIterator ita = a.getSliceIteratorFromAxes(null, achoice);
@@ -249,6 +251,7 @@ public class LinearAlgebra {
 		if (isa != 1 || isb != 1) {
 			throw new UnsupportedOperationException("Compound datasets not supported");
 		}
+		@SuppressWarnings("deprecation")
 		Dataset o = DatasetFactory.zeros(shape, DTypeUtils.getBestDType(a.getDType(), b.getDType()));
 
 		IndexIterator ita = a.getIterator();
@@ -397,6 +400,7 @@ public class LinearAlgebra {
 		List<int[]> fullShapes = BroadcastUtils.broadcastShapes(shapeA, shapeB);
 
 		int[] maxShape = fullShapes.get(0);
+		@SuppressWarnings("deprecation")
 		Dataset c = DatasetFactory.zeros(maxShape, DTypeUtils.getBestDType(a.getDType(), b.getDType()));
 
 		PositionIterator ita = a.getPositionIterator(axisA);
@@ -437,6 +441,7 @@ public class LinearAlgebra {
 			throw new IllegalArgumentException("Axis C argument exceeds rank");
 		}
 		maxShape = addAxisToShape(maxShape, axisC, 3);
+		@SuppressWarnings("deprecation")
 		Dataset c = DatasetFactory.zeros(maxShape, DTypeUtils.getBestDType(a.getDType(), b.getDType()));
 
 		PositionIterator ita = a.getPositionIterator(axisA);
@@ -612,6 +617,7 @@ public class LinearAlgebra {
 		for (int i = 0; i < r; i++) {
 			nShape[i] = aShape[i] * bShape[i];
 		}
+		@SuppressWarnings("deprecation")
 		Dataset kron = DatasetFactory.zeros(nShape, DTypeUtils.getBestDType(a.getDType(), b.getDType()));
 		IndexIterator ita = a.getIterator(true);
 		IndexIterator itb = b.getIterator(true);
@@ -682,6 +688,7 @@ public class LinearAlgebra {
 		int[] axes = new int[] { a.checkAxis(axis1), a.checkAxis(axis2) };
 		Arrays.sort(axes);
 		int is = a.getElementsPerItem();
+		@SuppressWarnings("deprecation")
 		Dataset trace = DatasetFactory.zeros(is, removeAxesFromShape(shape, axes), a.getDType());
 
 		int am = axes[0];

--- a/org.eclipse.january/src/org/eclipse/january/dataset/Maths.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/Maths.java
@@ -2460,6 +2460,7 @@ public class Maths extends GeneratedMaths {
 	 * @param axis
 	 * @return difference
 	 */
+	@SuppressWarnings("deprecation")
 	public static Dataset difference(Dataset a, final int n, int axis) {
 		Dataset ds;
 		final int dt = a.getDType();
@@ -2557,6 +2558,7 @@ public class Maths extends GeneratedMaths {
 	 *            smoothing, the higher the value, the more smoothing occurs.
 	 * @return A dataset which contains all the derivative point for point.
 	 */
+	@SuppressWarnings("deprecation")
 	public static Dataset derivative(Dataset x, Dataset y, int n) {
 		if (x.getRank() != 1 || y.getRank() != 1) {
 			throw new IllegalArgumentException("Only one dimensional dataset supported");
@@ -2632,6 +2634,7 @@ public class Maths extends GeneratedMaths {
 	 * @param axis
 	 * @return difference
 	 */
+	@SuppressWarnings("deprecation")
 	public static Dataset centralDifference(Dataset a, int axis) {
 		Dataset ds;
 		final int dt = a.getDType();
@@ -2942,6 +2945,7 @@ public class Maths extends GeneratedMaths {
 				} else {
 					final int dt = dx.getDType();
 					final int is = dx.getElementsPerItem();
+					@SuppressWarnings("deprecation")
 					final Dataset bdx = DatasetFactory.zeros(is, y.getShapeRef(), dt);
 					final PositionIterator pi = y.getPositionIterator(a);
 					final int[] pos = pi.getPos();

--- a/org.eclipse.january/src/org/eclipse/january/dataset/RGBDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/RGBDataset.java
@@ -573,6 +573,7 @@ public class RGBDataset extends CompoundShortDataset implements Cloneable {
 	 * @return a grey-scale dataset of given type
 	 */
 	public Dataset createGreyDataset(final double red, final double green, final double blue, final int dtype) {
+		@SuppressWarnings("deprecation")
 		final Dataset grey = DatasetFactory.zeros(shape, dtype);
 		final IndexIterator it = getIterator();
 
@@ -611,6 +612,7 @@ public class RGBDataset extends CompoundShortDataset implements Cloneable {
 	}
 
 	private Dataset createColourChannelDataset(final int channelOffset, final int dtype, final String cName) {
+		@SuppressWarnings("deprecation")
 		final Dataset channel = DatasetFactory.zeros(shape, dtype);
 
 		final StringBuilder cname = name == null ? new StringBuilder() : new StringBuilder(name);

--- a/org.eclipse.january/src/org/eclipse/january/dataset/SingleInputBroadcastIterator.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/SingleInputBroadcastIterator.java
@@ -81,6 +81,7 @@ public class SingleInputBroadcastIterator extends IndexIterator {
 	 * @param allowInteger if true, can create integer datasets
 	 * @param allowComplex if true, can create complex datasets
 	 */
+	@SuppressWarnings("deprecation")
 	public SingleInputBroadcastIterator(Dataset a, Dataset o, boolean createIfNull, boolean allowInteger, boolean allowComplex) {
 		List<int[]> fullShapes = BroadcastUtils.broadcastShapes(a.getShapeRef(), o == null ? null : o.getShapeRef());
 

--- a/org.eclipse.january/src/org/eclipse/january/dataset/Stats.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/Stats.java
@@ -129,6 +129,7 @@ public class Stats {
 
 		QStatisticsImpl<double[]> qstats = new QStatisticsImpl<double[]>();
 
+		@SuppressWarnings("deprecation")
 		Dataset w = DatasetFactory.zeros(a.getShapeRef(), a.getDType());
 		double[] q1 = new double[is];
 		double[] q2 = new double[is];
@@ -183,6 +184,7 @@ public class Stats {
 				qstats.setQuantile(axis, QStatisticsImpl.Q3, pQuantile(s, axis, QStatisticsImpl.Q3));
 				qstats.setSortedDataset(axis, s);
 			} else {
+				@SuppressWarnings("deprecation")
 				Dataset w = DatasetFactory.zeros(a.getShapeRef(), a.getDType());
 				CompoundDoubleDataset q1 = null, q2 = null, q3 = null;
 				for (int j = 0; j < is; j++) {
@@ -238,6 +240,7 @@ public class Stats {
 
 		oshape[axis] = 1;
 		int[] qshape = ShapeUtils.squeezeShape(oshape, false);
+		@SuppressWarnings("deprecation")
 		Dataset qds = DatasetFactory.zeros(is, qshape, Dataset.FLOAT64);
 
 		IndexIterator qiter = qds.getIterator(true);
@@ -262,6 +265,7 @@ public class Stats {
 			qiter = qds.getIterator(true);
 			qpos = qiter.getPos();
 			qpt++;
+			@SuppressWarnings("deprecation")
 			Dataset rds = DatasetFactory.zeros(is, qshape, Dataset.FLOAT64);
 			
 			while (qiter.hasNext()) {
@@ -338,7 +342,7 @@ public class Stats {
 	 * @param values
 	 * @return points at which CDF has given values
 	 */
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({ "unchecked", "deprecation" })
 	public static Dataset[] quantile(final Dataset a, final int axis, final double... values) {
 		final Dataset[] points  = new Dataset[values.length];
 		final int is = a.getElementsPerItem();
@@ -609,6 +613,7 @@ public class Stats {
 		return stats;
 	}
 
+	@SuppressWarnings("deprecation")
 	static private HigherStatisticsImpl<?> calculateHigherMoments(final Dataset a, final boolean ignoreNaNs, final boolean ignoreInfs, final int axis) {
 		final int rank = a.getRank();
 		final int is = a.getElementsPerItem();
@@ -969,6 +974,7 @@ public class Stats {
 			ignoreNaNs = false;
 			ignoreInfs = false;
 		}
+		@SuppressWarnings("deprecation")
 		Dataset result = DatasetFactory.zeros(is, oshape, dtype);
 
 		IndexIterator qiter = result.getIterator(true);

--- a/org.eclipse.january/src/org/eclipse/january/metadata/internal/StatisticsMetadataImpl.java
+++ b/org.eclipse.january/src/org/eclipse/january/metadata/internal/StatisticsMetadataImpl.java
@@ -516,6 +516,7 @@ public class StatisticsMetadataImpl<T> implements StatisticsMetadata<T> {
 	 * @param ignoreInfs if true, ignore infinities
 	 * @param axis
 	 */
+	@SuppressWarnings("deprecation")
 	private Dataset[] createAxisStats(final int axis, final boolean ignoreNaNs, final boolean ignoreInfs) {
 		int rank = dataset.getRank();
 


### PR DESCRIPTION
As agreed in #24 

I've applied the `@Suppress` to the smallest applicable block of code in each case. 

Signed-off-by: Ian Mayo <ian@planetmayo.com>