### PR TITLE
Update target platform to use R build of Orbit

### DIFF
--- a/releng/org.eclipse.january.releng.target/org.eclipse.january.releng.target.target
+++ b/releng/org.eclipse.january.releng.target/org.eclipse.january.releng.target.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/mbarbero/fr.obeo.releng.targetplatform -->
-<target name="January" sequenceNumber="1487951933">
+<target name="January" sequenceNumber="1489178694">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.slf4j.api" version="1.7.2.v20121108-1250"/>
@@ -11,7 +11,7 @@
       <unit id="org.junit" version="4.12.0.v201504281640"/>
       <unit id="org.mockito" version="1.9.5.v201605172210"/>
       <unit id="org.hamcrest" version="1.1.0.v20090501071000"/>
-      <repository id="eclipse-orbit-oxygen-m5" location="http://download.eclipse.org/tools/orbit/downloads/drops/S20170120205402/repository"/>
+      <repository id="eclipse-orbit-neon-sr3" location="http://download.eclipse.org/tools/orbit/downloads/drops/R20170307180635/repository"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.equinox.launcher" version="0.0.0"/>

--- a/releng/org.eclipse.january.releng.target/org.eclipse.january.releng.target.tpd
+++ b/releng/org.eclipse.january.releng.target/org.eclipse.january.releng.target.tpd
@@ -11,10 +11,7 @@
  *******************************************************************************/
 target "January" with source requirements
 
-// Using Orbit Oxygen S build at the moment. The Orbit S build contains some items
-// that the most recent R build does not (e.g. org.apache.commons.math3).
-
-location "http://download.eclipse.org/tools/orbit/downloads/drops/S20170120205402/repository" eclipse-orbit-oxygen-m5 {
+location "http://download.eclipse.org/tools/orbit/downloads/drops/R20170307180635/repository" eclipse-orbit-neon-sr3 {
 
 // The versions we point to in Orbit are the versions we have CQs approved for, please
 // raise CQ for items not in this list or version changes


### PR DESCRIPTION
Until now all new style Oribit bundles were never released in an R
build. Even though this is called a Neon build it contains
the correct versions of the bundles we require for January.

Signed-off-by: Jonah Graham <jonah@kichwacoders.com>