### PR TITLE
Rename UnsignedArithmetics to ...Test

### DIFF
--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/AllSuite.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/AllSuite.java
@@ -29,7 +29,7 @@ import org.junit.runners.Suite.SuiteClasses;
 		PositionIteratorTest.class, RandomTest.class, RGBDatasetTest.class, ShortDatasetTest.class,
 		SingleInputBroadcastIteratorTest.class, SliceIteratorTest.class, SliceNDIteratorTest.class, SliceNDTest.class,
 		SliceTest.class, StatsTest.class, StrideIteratorTest.class, StringDatasetTest.class,
-		UnsignedArithmetics.class,
+		UnsignedArithmeticsTest.class,
 		OutlierCorrectnessTest.class, OutlierStatsTest.class,
 		org.eclipse.january.metadata.AllSuite.class,
 		})

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/UnsignedArithmeticsTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/UnsignedArithmeticsTest.java
@@ -17,7 +17,7 @@ import org.junit.Test;
  * Check out arithmetic with unsigned numbers
  * 
  */
-public class UnsignedArithmetics {
+public class UnsignedArithmeticsTest {
 	final static int MAX = 1 << Byte.SIZE;
 
 	@Test


### PR DESCRIPTION
There was an UnsignedArithmetics in both the test bundle and the
main bundle with the same name. Until now that caused no problem
that anyone noticed, but today PDE decided to complain.

Signed-off-by: Jonah Graham <jonah@kichwacoders.com>