### PR TITLE
Correct PyDev configuration

### DIFF
--- a/org.eclipse.january/.pydevproject
+++ b/org.eclipse.january/.pydevproject
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?eclipse-pydev version="1.0"?><pydev_project>
-<pydev_property name="org.python.pydev.PYTHON_PROJECT_INTERPRETER">Default</pydev_property>
-<pydev_property name="org.python.pydev.PYTHON_PROJECT_VERSION">python 2.7</pydev_property>
+<pydev_property name="org.python.pydev.PYTHON_PROJECT_INTERPRETER">Jython2</pydev_property>
+<pydev_property name="org.python.pydev.PYTHON_PROJECT_VERSION">jython 2.7</pydev_property>
+<pydev_pathproperty name="org.python.pydev.PROJECT_SOURCE_PATH">
+<path>/${PROJECT_DIR_NAME}/bin</path>
+</pydev_pathproperty>
 </pydev_project>


### PR DESCRIPTION
Switch to a Jython interpreter called Jython2 and include the class file directory to enable runners launched from the IDE to find built classes