### PR TITLE
profile for unix command

### DIFF
--- a/org.eclipse.january/pom.xml
+++ b/org.eclipse.january/pom.xml
@@ -5,9 +5,9 @@
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
-   
+
     Contributors:
-        Diamond Light Source Ltd - initial API and implementation
+	Diamond Light Source Ltd - initial API and implementation
  -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -22,39 +22,55 @@
 		<version>2.1.0-SNAPSHOT</version>
 	</parent>
 	<packaging>eclipse-plugin</packaging>
+
+	<profiles>
+		<profile>
+			<id>unix</id>
+			<activation>
+				<os>
+					<family>unix</family>
+				</os>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<artifactId>exec-maven-plugin</artifactId>
+						<groupId>org.codehaus.mojo</groupId>
+						<version>1.5.0</version>
+						<executions>
+							<execution>
+								<id>Verify generated files are up to date</id>
+								<phase>generate-sources</phase>
+								<goals>
+									<goal>exec</goal>
+								</goals>
+							</execution>
+						</executions>
+						<configuration>
+							<executable>${basedir}/src/org/eclipse/january/dataset/internal/template/verify_all.sh</executable>
+							<workingDirectory>${basedir}/src/org/eclipse/january/dataset/internal/template</workingDirectory>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+
 	<build>
 		<plugins>
 			<plugin>
-				<artifactId>exec-maven-plugin</artifactId>
-				<groupId>org.codehaus.mojo</groupId>
-				<version>1.5.0</version>
-				<executions>
-					<execution>
-						<id>Verify generated files are up to date</id>
-						<phase>generate-sources</phase>
-						<goals>
-							<goal>exec</goal>
-						</goals>
-					</execution>
-				</executions>
-				<configuration>
-					<executable>${basedir}/src/org/eclipse/january/dataset/internal/template/verify_all.sh</executable>
-					<workingDirectory>${basedir}/src/org/eclipse/january/dataset/internal/template</workingDirectory>
-				</configuration>
-			</plugin>
-			<plugin>
 				<!-- this plug-in splits version so that below the title can exclude the -SNAPSHOT
-			         http://stackoverflow.com/questions/13347796/manipulate-project-version-property-to-remove-snapshot
+				 http://stackoverflow.com/questions/13347796/manipulate-project-version-property-to-remove-snapshot
 			     -->
 				<artifactId>build-helper-maven-plugin</artifactId>
 				<groupId>org.codehaus.mojo</groupId>
 				<version>3.0.0</version>
 				<executions>
 					<execution>
-					<id>parse-version</id>
-					<goals>
-						<goal>parse-version</goal>
-					</goals>
+						<id>parse-version</id>
+						<goals>
+							<goal>parse-version</goal>
+						</goals>
 					</execution>
 				</executions>
 			</plugin>


### PR DESCRIPTION
The exec-maven-plugin is executing a .sh file, which windows can't do.
I created a profile activated by being on a unix based platform that runs this plugin.