### PR TITLE
Added an exception case to crossings in DatasetUtils

### DIFF
--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/DatasetUtilsTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/DatasetUtilsTest.java
@@ -20,4 +20,11 @@ public class DatasetUtilsTest {
 		DatasetUtils.split(dataset, indices, 1);
 	}
 
+	@Test(expected = IllegalArgumentException.class)
+	public void testCrossingsException() {
+		Dataset xAxis = DatasetFactory.createFromObject(new Double[] { 0.0, 0.0, 0.0 });
+		Dataset yAxis = DatasetFactory.createFromObject(new Double[] { 0.0, 0.0 });
+		DatasetUtils.crossings(xAxis, yAxis, 0);
+	}
+
 }

--- a/org.eclipse.january/src/org/eclipse/january/dataset/DatasetUtils.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/DatasetUtils.java
@@ -1714,6 +1714,11 @@ public class DatasetUtils {
 	 * @return An list of doubles containing all the X coordinates of where the line crosses
 	 */
 	public static List<Double> crossings(Dataset xAxis, Dataset yAxis, double yValue) {
+		if (xAxis.getSize() > yAxis.getSize()) {
+			throw new IllegalArgumentException(
+					"Number of values of yAxis must as least be equal to the number of values of xAxis");
+		}
+		
 		List<Double> results = new ArrayList<Double>();
 
 		List<Double> indices = crossings(yAxis, yValue);


### PR DESCRIPTION
It now checks if the number of values on the yAxis is at least equal to the
number of values on the xAxis. If this is not the case, it raises a
IllegalArgumentException.

Signed-off-by: Yannick Mayeur <yannick.mayeur@gmail.com>