### PR TITLE
Fix crossings not working properly in DatasetUtils

### DIFF
--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/DatasetUtilsTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/DatasetUtilsTest.java
@@ -10,6 +10,11 @@
 package org.eclipse.january.dataset;
 
 import org.eclipse.january.asserts.TestUtils;
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.Test;
 
 public class DatasetUtilsTest {
@@ -38,4 +43,15 @@ public class DatasetUtilsTest {
 		TestUtils.assertDatasetEquals(DatasetFactory.createFromObject(ShortDataset.class, new short[] {0, 255, 128}), DatasetUtils.makeUnsigned(neg, false));
 		TestUtils.assertDatasetEquals(DatasetFactory.createFromObject(ShortDataset.class, new short[] {0, 255, 128}), DatasetUtils.makeUnsigned(neg, true));
 	}
+
+	@Test
+	public void testCrossings3() {
+		Dataset yAxis = DatasetFactory.createFromObject(new Double[] { 0.5, 1.1, 0.9, 1.5 });
+		Dataset xAxis = DatasetFactory.createFromObject(new Double[] { 1.0, 2.0, 3.0, 4.0 });
+		List<Double> expected = new ArrayList<Double>();
+		expected.add(2.5);
+		List<Double> actual = DatasetUtils.crossings(xAxis, yAxis, 1, 0.5);
+		assertEquals(expected, actual);
+	}
+	
 }

--- a/org.eclipse.january/src/org/eclipse/january/dataset/DatasetUtils.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/DatasetUtils.java
@@ -1772,7 +1772,7 @@ public class DatasetUtils {
 		int i = 0;
 		// now go through and check for groups of three crossings which are all
 		// within the boundaries
-		while (i < vals.size() - 3) {
+		while (i <= vals.size() - 3) {
 			double v1 = Math.abs(vals.get(i) - vals.get(i + 2));
 			if (v1 < error) {
 				// these 3 points should be treated as one


### PR DESCRIPTION
crossings(Dataset xAxis, Dataset yAxis, double yValue, double xRangeProportion)
not working properly.
If there are exactly 3 crossings that could have been merged it is not done
because it was using "<" instead of "<=".
![w6-1](https://cloud.githubusercontent.com/assets/14848887/26443510/96664450-4130-11e7-9a7f-b35db88197bb.png)

Signed-off-by: Yannick Mayeur <yannick.mayeur@gmail.com>