### PR TITLE
Remove aggregation of boolean elements

### DIFF
--- a/org.eclipse.january/src/org/eclipse/january/dataset/CompoundByteDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/CompoundByteDataset.java
@@ -455,12 +455,7 @@ public class CompoundByteDataset extends AbstractCompoundDataset {
 
 	@Override
 	public boolean getElementBooleanAbs(final int index) {
-		for (int i = 0; i < isize; i++) {
-			if (data[index + i] == 0) {
-				return false;
-			}
-		}
-		return true;
+		return data[index] != 0;
 	}
 
 	@Override

--- a/org.eclipse.january/src/org/eclipse/january/dataset/CompoundDoubleDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/CompoundDoubleDataset.java
@@ -455,12 +455,7 @@ public class CompoundDoubleDataset extends AbstractCompoundDataset {
 
 	@Override
 	public boolean getElementBooleanAbs(final int index) {
-		for (int i = 0; i < isize; i++) {
-			if (data[index + i] == 0) {
-				return false;
-			}
-		}
-		return true;
+		return data[index] != 0;
 	}
 
 	@Override

--- a/org.eclipse.january/src/org/eclipse/january/dataset/CompoundFloatDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/CompoundFloatDataset.java
@@ -455,12 +455,7 @@ public class CompoundFloatDataset extends AbstractCompoundDataset {
 
 	@Override
 	public boolean getElementBooleanAbs(final int index) {
-		for (int i = 0; i < isize; i++) {
-			if (data[index + i] == 0) {
-				return false;
-			}
-		}
-		return true;
+		return data[index] != 0;
 	}
 
 	@Override

--- a/org.eclipse.january/src/org/eclipse/january/dataset/CompoundIntegerDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/CompoundIntegerDataset.java
@@ -455,12 +455,7 @@ public class CompoundIntegerDataset extends AbstractCompoundDataset {
 
 	@Override
 	public boolean getElementBooleanAbs(final int index) {
-		for (int i = 0; i < isize; i++) {
-			if (data[index + i] == 0) {
-				return false;
-			}
-		}
-		return true;
+		return data[index] != 0;
 	}
 
 	@Override

--- a/org.eclipse.january/src/org/eclipse/january/dataset/CompoundLongDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/CompoundLongDataset.java
@@ -455,12 +455,7 @@ public class CompoundLongDataset extends AbstractCompoundDataset {
 
 	@Override
 	public boolean getElementBooleanAbs(final int index) {
-		for (int i = 0; i < isize; i++) {
-			if (data[index + i] == 0) {
-				return false;
-			}
-		}
-		return true;
+		return data[index] != 0;
 	}
 
 	@Override

--- a/org.eclipse.january/src/org/eclipse/january/dataset/CompoundShortDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/CompoundShortDataset.java
@@ -455,12 +455,7 @@ public class CompoundShortDataset extends AbstractCompoundDataset {
 
 	@Override
 	public boolean getElementBooleanAbs(final int index) {
-		for (int i = 0; i < isize; i++) {
-			if (data[index + i] == 0) {
-				return false;
-			}
-		}
-		return true;
+		return data[index] != 0;
 	}
 
 	@Override


### PR DESCRIPTION
This is because it violates common pattern for getElement*Abs and can cause ArrayIndexOutOfBound exceptions