### PR TITLE
Speed up set dirty as it is called in all dataset item setters

### DIFF
--- a/org.eclipse.january/src/org/eclipse/january/dataset/AbstractDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/AbstractDataset.java
@@ -1320,11 +1320,6 @@ public abstract class AbstractDataset extends LazyDatasetBase implements Dataset
 	}
 
 	@Override
-	public void setDirty() {
-		dirtyMetadata();
-	}
-
-	@Override
 	public Dataset squeezeEnds() {
 		return squeeze(true);
 	}

--- a/org.eclipse.january/src/org/eclipse/january/dataset/Dataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/Dataset.java
@@ -230,7 +230,7 @@ public interface Dataset extends IDataset {
 	public Dataset clone();
 
 	/**
-	 * This method allows anything that dirties the dataset to clear stored values
+	 * This method allows anything that dirties the dataset to clear various metadata values
 	 * so that the other methods can work correctly.
 	 */
 	public void setDirty();

--- a/org.eclipse.january/src/org/eclipse/january/dataset/LazyDatasetBase.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/LazyDatasetBase.java
@@ -60,6 +60,7 @@ public abstract class LazyDatasetBase implements ILazyDataset, Serializable {
 		}
 	}
 
+	transient private boolean dirty = true; // indicate dirty state of metadata
 	protected String name = "";
 
 	/**
@@ -137,6 +138,14 @@ public abstract class LazyDatasetBase implements ILazyDataset, Serializable {
 	@Override
 	public int getRank() {
 		return shape.length;
+	}
+
+	/**
+	 * This method allows anything that dirties the dataset to clear various metadata values
+	 * so that the other methods can work correctly.
+	 */
+	public void setDirty() {
+		dirty = true;
 	}
 
 	/**
@@ -234,6 +243,11 @@ public abstract class LazyDatasetBase implements ILazyDataset, Serializable {
 	public synchronized <S extends MetadataType, T extends S> List<S> getMetadata(Class<T> clazz) throws MetadataException {
 		if (metadata == null)
 			return null;
+
+		if (dirty) {
+			dirtyMetadata();
+			dirty = false;
+		}
 
 		if (clazz == null) {
 			List<S> all = new ArrayList<S>();


### PR DESCRIPTION
Defer dirtyMetadata call until metadata is fetched