### PR TITLE
Switch to using OpenJDK 7 to build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ services:
   - docker
 
 jdk:
- - oraclejdk7
+ - openjdk7
 
 # don't do anything on install, just let maven install the dependencies in the script
 # Also see https://github.com/eclipse/january/issues/109


### PR DESCRIPTION
Travis-CI has updated their Ubuntu Trusty 14.04 images and it looks like it no longer has oraclejdk7