### PR TITLE
Switch to using OpenJDK 7 to build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ services:
   - docker
 
 jdk:
- - oraclejdk7
+ - openjdk7
 
 # Check they had a ticket with this change
 # before_install:


### PR DESCRIPTION
Travis-CI has updated their Ubuntu Trusty 14.04 images and it looks like it no longer has oraclejdk7

Cherry-picked from #219 4e1601a4623a7f6c2c9c0737d89d71a2460bf146