### PR TITLE
Fix bug in slicing metadata with broadcasting and a step > 1

### DIFF
--- a/org.eclipse.january.test/src/org/eclipse/january/metadata/internal/SliceableMetadataTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/metadata/internal/SliceableMetadataTest.java
@@ -27,6 +27,7 @@ import org.eclipse.january.dataset.ILazyDataset;
 import org.eclipse.january.dataset.Random;
 import org.eclipse.january.dataset.ShortDataset;
 import org.eclipse.january.dataset.Slice;
+import org.eclipse.january.dataset.SliceND;
 import org.junit.Test;
 
 public class SliceableMetadataTest {
@@ -145,6 +146,30 @@ public class SliceableMetadataTest {
 			assertArrayEquals(sliced.getShape(), tmd.getMap().get("1").getShape());
 			assertArrayEquals(sliced.getShape(), tmd.getLazyDataset2().getShape());
 			assertArrayEquals(sliced.getShape(), tmd.getListOfArrays().get(0)[0].getShape());
+		} catch (Exception e) {
+			fail("Should not fail: " + e);
+		}
+	}
+	
+	@Test
+	public void testStepBroadcasted() {
+		
+		final int[] bshape = new int[] {1, 5, 1};
+		final int[] shape = new int[] {4, 5, 6};
+		ILazyDataset ld = Random.lazyRand(Dataset.INT32, "Metadata1", bshape);
+		SliceableTestMetadata md = new SliceableTestMetadata(ld, null, null, null, null);
+
+		ILazyDataset dataset = Random.lazyRand(Dataset.INT32, "Main", shape);
+		dataset.addMetadata(md);
+		
+		try {
+			SliceND snd = new SliceND(dataset.getShape());
+			snd.setSlice(1, 0, 5, 2);
+			ILazyDataset slicedStep = dataset.getSliceView(snd);
+			SliceableTestMetadata tmd = slicedStep.getFirstMetadata(SliceableTestMetadata.class);
+			ILazyDataset lazyDataset = tmd.getLazyDataset();
+			assertEquals(slicedStep.getShape()[1], lazyDataset.getShape()[1]);
+			
 		} catch (Exception e) {
 			fail("Should not fail: " + e);
 		}

--- a/org.eclipse.january/src/org/eclipse/january/dataset/LazyDatasetBase.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/LazyDatasetBase.java
@@ -423,7 +423,7 @@ public abstract class LazyDatasetBase implements ILazyDataset, Serializable {
 					if (shape[i] == 1) {
 						stt[i] = 0;
 						stp[i] = 1;
-						ste[1] = 1;
+						ste[i] = 1;
 					} else {
 						throw new IllegalArgumentException("Sliceable dataset has invalid size!");
 					}


### PR DESCRIPTION
Includes simple test that fails without the fix