### PR TITLE
Fix #302 by making a deeper copy of the original metadata on restore

### DIFF
--- a/org.eclipse.january.test/src/org/eclipse/january/metadata/internal/AxesMetadataTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/metadata/internal/AxesMetadataTest.java
@@ -268,4 +268,26 @@ public class AxesMetadataTest {
 		IDataset slice = view.getSlice();
 		assertTrue(slice != null);
 	}
+
+	@Test
+	public void testSliceOfSqueezed() throws DatasetException {
+		final int[] shape = new int[] { 3, 10, 1 };
+
+		ILazyDataset dataset = Random.lazyRand(shape);
+		Dataset ax = Random.rand(shape[0]);
+		Dataset bx = Random.rand(shape[1]);
+
+		AxesMetadata amd = MetadataFactory.createMetadata(AxesMetadata.class, shape.length);
+		amd.setAxis(0, ax);
+		amd.setAxis(1, bx);
+		dataset.setMetadata(amd);
+
+		ILazyDataset nd;
+		IDataset slice;
+
+		nd = dataset.getSliceView().squeezeEnds(); // axes metadata now possess different shapes
+		slice = nd.getSlice(new Slice(1, 2), null); // this used to alter the original axes metadata
+		slice = nd.getSlice(new Slice(1, 2), null);
+		assertTrue(slice != null);
+	}
 }

--- a/org.eclipse.january/src/org/eclipse/january/dataset/LazyDatasetBase.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/LazyDatasetBase.java
@@ -316,16 +316,20 @@ public abstract class LazyDatasetBase implements ILazyDataset, Serializable {
 		}
 
 		ConcurrentHashMap<Class<? extends MetadataType>, List<MetadataType>> map = new ConcurrentHashMap<Class<? extends MetadataType>, List<MetadataType>>();
+		copyMetadata(metadata, map);
+		return map;
+	}
 
-		for (Class<? extends MetadataType> c : metadata.keySet()) {
-			List<MetadataType> l = metadata.get(c);
+	private static void copyMetadata(Map<Class<? extends MetadataType>, List<MetadataType>> inMetadata,
+			Map<Class<? extends MetadataType>, List<MetadataType>> outMetadata) {
+		for (Class<? extends MetadataType> c : inMetadata.keySet()) {
+			List<MetadataType> l = inMetadata.get(c);
 			List<MetadataType> nl = new ArrayList<MetadataType>(l.size());
-			map.put(c, nl);
+			outMetadata.put(c, nl);
 			for (MetadataType m : l) {
 				nl.add(m.clone());
 			}
 		}
-		return map;
 	}
 
 	interface MetadatasetAnnotationOperation {
@@ -982,9 +986,7 @@ public abstract class LazyDatasetBase implements ILazyDataset, Serializable {
 	}
 
 	protected void restoreMetadata(Map<Class<? extends MetadataType>, List<MetadataType>> oldMetadata) {
-		for (Class<? extends MetadataType> mc : oldMetadata.keySet()) {
-			metadata.put(mc, oldMetadata.get(mc));
-		}
+		copyMetadata(oldMetadata, metadata);
 	}
 
 	protected ILazyDataset createFromSerializable(Serializable blob, boolean keepLazy) {


### PR DESCRIPTION
Metadata slicing (and other processing) works on datasets in place thus we need to ensure we do not overwrite the original metadata that is restored on slicing