### PR TITLE
Fix 306 by using an ND slice

### DIFF
--- a/org.eclipse.january.test/src/org/eclipse/january/metadata/internal/AxesMetadataTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/metadata/internal/AxesMetadataTest.java
@@ -301,4 +301,30 @@ public class AxesMetadataTest {
 		ErrorMetadata em = ax.getSlice().getFirstMetadata(ErrorMetadata.class);
 		assertTrue(em == null);
 	}
+
+	@Test
+	public void testReversedSlice() throws DatasetException {
+		final int[] shape = new int[] {3, 10};
+	
+		ILazyDataset dataset = Random.lazyRand(shape);
+		Dataset ax = Random.rand(shape[0]);
+		Dataset bx = Random.rand(shape[1]);
+	
+		AxesMetadata amd = MetadataFactory.createMetadata(AxesMetadata.class, shape.length);
+		amd.setAxis(0, ax);
+		amd.setAxis(1, bx);
+		dataset.setMetadata(amd);
+	
+		IDataset slice;
+	
+		slice = dataset.getSlice((Slice) null, new Slice(null, 7));
+		amd = slice.getFirstMetadata(AxesMetadata.class);
+		assertEquals(ax.getSize(), amd.getAxes()[0].getSize());
+		assertEquals(7, amd.getAxes()[1].getSize());
+	
+		slice = dataset.getSlice((Slice) null, new Slice(7, null, -1));
+		amd = slice.getFirstMetadata(AxesMetadata.class);
+		assertEquals(ax.getSize(), amd.getAxes()[0].getSize());
+		assertEquals(8, amd.getAxes()[1].getSize());
+	}
 }

--- a/org.eclipse.january/src/org/eclipse/january/dataset/LazyDatasetBase.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/LazyDatasetBase.java
@@ -314,7 +314,7 @@ public abstract class LazyDatasetBase implements ILazyDataset, Serializable {
 
 	/**
 	 * Copy metadata. If oMetadata is not null, then copy from that when it has the corresponding items
-	 * @since 2.1.2
+	 * @since 2.1
 	 * @param metadata
 	 * @param oMetadata can be null
 	 * @return
@@ -378,18 +378,14 @@ public abstract class LazyDatasetBase implements ILazyDataset, Serializable {
 
 	class MdsSlice implements MetadatasetAnnotationOperation {
 		private boolean asView;
-		private int[] start;
-		private int[] stop;
-		private int[] step;
+		private SliceND slice;
 		private int[] oShape;
 		private long oSize;
 
-		public MdsSlice(boolean asView, final int[] start, final int[] stop, final int[] step, final int[] oShape) {
+		public MdsSlice(boolean asView, SliceND slice) {
 			this.asView = asView;
- 			this.start = start;
-			this.stop = stop;
-			this.step = step;
-			this.oShape = oShape;
+			this.slice = slice;
+			oShape = slice.getSourceShape();
 			oSize = ShapeUtils.calcLongSize(oShape);
 		}
 
@@ -416,28 +412,20 @@ public abstract class LazyDatasetBase implements ILazyDataset, Serializable {
 		@Override
 		public ILazyDataset run(ILazyDataset lz) {
 			int rank = lz.getRank();
-			if (start.length != rank) {
+			if (slice.getStart().length != rank) {
 				throw new IllegalArgumentException("Slice dimensions do not match dataset!");
 			}
 
 			int[] shape = lz.getShape();
-			int[] stt;
-			int[] stp;
-			int[] ste;
+			SliceND nslice;
 			if (lz.getSize() == oSize) {
-				stt = start;
-				stp = stop;
-				ste = step;
+				nslice = slice;
 			} else {
-				stt = start.clone();
-				stp = stop.clone();
-				ste = step.clone();
+				nslice = slice.clone();
 				for (int i = 0; i < rank; i++) {
 					if (shape[i] >= oShape[i]) continue;
 					if (shape[i] == 1) {
-						stt[i] = 0;
-						stp[i] = 1;
-						ste[i] = 1;
+						nslice.setSlice(i, 0, 1, 1);
 					} else {
 						throw new IllegalArgumentException("Sliceable dataset has invalid size!");
 					}
@@ -445,9 +433,9 @@ public abstract class LazyDatasetBase implements ILazyDataset, Serializable {
 			}
 
 			if (asView || (lz instanceof IDataset))
-				return lz.getSliceView(stt, stp, ste);
+				return lz.getSliceView(nslice);
 			try {
-				return lz.getSlice(stt, stp, ste);
+				return lz.getSlice(nslice);
 			} catch (DatasetException e) {
 				logger.error("Could not slice dataset in metadata", e);
 				return null;
@@ -780,7 +768,7 @@ public abstract class LazyDatasetBase implements ILazyDataset, Serializable {
 	 * @param slice
 	 */
 	protected void sliceMetadata(boolean asView, final SliceND slice) {
-		processAnnotatedMetadata(new MdsSlice(asView, slice.getStart(), slice.getStop(), slice.getStep(), slice.getSourceShape()), true);
+		processAnnotatedMetadata(new MdsSlice(asView, slice), true);
 	}
 
 	/**


### PR DESCRIPTION
Negative start/end points are re-interpreted when the 3-integer array getter is used