### PR TITLE
Fix lazy dataset slicing, transposing and shaping bugs

### DIFF
--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/LazyWriteableDatasetTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/LazyWriteableDatasetTest.java
@@ -84,5 +84,8 @@ public class LazyWriteableDatasetTest {
 		Dataset sd = DatasetFactory.ones(d.getClass(), s.getShape());
 		ld.setSlice(sd, s);
 		Assert.assertEquals(ld.getSlice(s), sd);
-	}	
+	}
+
+	// TODO test set slice on squeezed sliced view
+	
 }

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/ShapeUtilsTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/ShapeUtilsTest.java
@@ -11,6 +11,9 @@
 package org.eclipse.january.dataset;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
@@ -32,5 +35,139 @@ public class ShapeUtilsTest {
 
 		remain = ShapeUtils.getReducedShapeKeepRank(new int[] {2, 3, 4, 5}, 1, -2);
 		assertArrayEquals(new int[] {2, 1, 1, 5}, remain);
+	}
+
+	@Test
+	public void testDiffersByOnes() {
+		assertTrue(ShapeUtils.differsByOnes(new int[] {}, new int[] {}));
+		assertTrue(ShapeUtils.differsByOnes(new int[] {1, 1, 1}, new int[] {}));
+		assertTrue(ShapeUtils.differsByOnes(new int[] {}, new int[] {1, 1, 1}));
+
+		assertTrue(ShapeUtils.differsByOnes(new int[] {2}, new int[] {2}));
+		assertTrue(ShapeUtils.differsByOnes(new int[] {1, 1, 1, 2}, new int[] {2}));
+		assertTrue(ShapeUtils.differsByOnes(new int[] {1, 1, 1, 2}, new int[] {2, 1, 1, 1}));
+		assertTrue(ShapeUtils.differsByOnes(new int[] {2}, new int[] {2, 1, 1, 1}));
+		assertTrue(ShapeUtils.differsByOnes(new int[] {2}, new int[] {1, 1, 1, 2}));
+
+		assertTrue(ShapeUtils.differsByOnes(new int[] {2, 3}, new int[] {2, 3}));
+		assertTrue(ShapeUtils.differsByOnes(new int[] {1, 1, 1, 2, 3}, new int[] {2, 3}));
+		assertTrue(ShapeUtils.differsByOnes(new int[] {1, 1, 1, 2, 3}, new int[] {2, 3, 1, 1, 1}));
+		assertTrue(ShapeUtils.differsByOnes(new int[] {2, 3}, new int[] {2, 3, 1, 1, 1}));
+		assertTrue(ShapeUtils.differsByOnes(new int[] {2, 3}, new int[] {1, 1, 1, 2, 3}));
+
+		assertTrue(ShapeUtils.differsByOnes(new int[] {2, 3}, new int[] {2, 1, 1, 3}));
+		assertTrue(ShapeUtils.differsByOnes(new int[] {1, 1, 1, 2, 3}, new int[] {2, 1, 1, 3}));
+		assertTrue(ShapeUtils.differsByOnes(new int[] {1, 1, 1, 2, 3}, new int[] {2, 1, 1, 3, 1, 1, 1}));
+		assertTrue(ShapeUtils.differsByOnes(new int[] {2, 3}, new int[] {2, 1, 1, 3, 1, 1, 1}));
+		assertTrue(ShapeUtils.differsByOnes(new int[] {2, 3}, new int[] {1, 1, 1, 2, 1, 1, 3}));
+
+		assertTrue(ShapeUtils.differsByOnes(new int[] {2, 1, 1, 3}, new int[] {2, 3}));
+		assertTrue(ShapeUtils.differsByOnes(new int[] {1, 1, 1, 2, 1, 1, 3}, new int[] {2, 3}));
+		assertTrue(ShapeUtils.differsByOnes(new int[] {1, 1, 1, 2, 1, 1, 3}, new int[] {2, 3, 1, 1, 1}));
+		assertTrue(ShapeUtils.differsByOnes(new int[] {2, 1, 1, 3}, new int[] {2, 3, 1, 1, 1}));
+		assertTrue(ShapeUtils.differsByOnes(new int[] {2, 1, 1, 3}, new int[] {1, 1, 1, 2, 3}));
+
+		assertFalse(ShapeUtils.differsByOnes(new int[] {2}, new int[] {4}));
+		assertFalse(ShapeUtils.differsByOnes(new int[] {1, 1, 1, 2}, new int[] {4}));
+		assertFalse(ShapeUtils.differsByOnes(new int[] {1, 1, 1, 2}, new int[] {4, 1, 1, 1}));
+		assertFalse(ShapeUtils.differsByOnes(new int[] {2}, new int[] {4, 1, 1, 1}));
+		assertFalse(ShapeUtils.differsByOnes(new int[] {2}, new int[] {1, 1, 1, 4}));
+
+		assertFalse(ShapeUtils.differsByOnes(new int[] {2, 3}, new int[] {2, 4}));
+		assertFalse(ShapeUtils.differsByOnes(new int[] {1, 1, 1, 2, 3}, new int[] {2, 4}));
+		assertFalse(ShapeUtils.differsByOnes(new int[] {1, 1, 1, 2, 3}, new int[] {2, 4, 1, 1, 1}));
+		assertFalse(ShapeUtils.differsByOnes(new int[] {2, 3}, new int[] {2, 4, 1, 1, 1}));
+		assertFalse(ShapeUtils.differsByOnes(new int[] {2, 3}, new int[] {1, 1, 1, 2, 4}));
+
+		assertFalse(ShapeUtils.differsByOnes(new int[] {2, 3}, new int[] {2, 1, 1, 4}));
+		assertFalse(ShapeUtils.differsByOnes(new int[] {1, 1, 1, 2, 3}, new int[] {2, 1, 1, 4}));
+		assertFalse(ShapeUtils.differsByOnes(new int[] {1, 1, 1, 2, 3}, new int[] {2, 1, 1, 4, 1, 1, 1}));
+		assertFalse(ShapeUtils.differsByOnes(new int[] {2, 3}, new int[] {2, 1, 1, 4, 1, 1, 1}));
+		assertFalse(ShapeUtils.differsByOnes(new int[] {2, 3}, new int[] {1, 1, 1, 2, 1, 1, 4}));
+
+		assertFalse(ShapeUtils.differsByOnes(new int[] {2, 1, 1, 3}, new int[] {2, 4}));
+		assertFalse(ShapeUtils.differsByOnes(new int[] {1, 1, 1, 2, 1, 1, 3}, new int[] {2, 4}));
+		assertFalse(ShapeUtils.differsByOnes(new int[] {1, 1, 1, 2, 1, 1, 3}, new int[] {2, 4, 1, 1, 1}));
+		assertFalse(ShapeUtils.differsByOnes(new int[] {2, 1, 1, 3}, new int[] {2, 4, 1, 1, 1}));
+		assertFalse(ShapeUtils.differsByOnes(new int[] {2, 1, 1, 3}, new int[] {1, 1, 1, 2, 4}));
+	}
+
+	@Test
+	public void testCalcShapePadding() {
+		assertNull(ShapeUtils.calcShapePadding(null, null));
+
+		assertNull(ShapeUtils.calcShapePadding(new int[0], new int[0]));
+
+		assertNull(ShapeUtils.calcShapePadding(new int[] {2,1,3}, new int[] {2,1,3}));
+
+		assertArrayEquals(new int[] {-2}, ShapeUtils.calcShapePadding(new int[] {1, 1}, new int[] {}));
+		assertArrayEquals(new int[] {2}, ShapeUtils.calcShapePadding(new int[] {}, new int[] {1, 1}));
+
+		assertArrayEquals(new int[] {1,0}, ShapeUtils.calcShapePadding(new int[] {2}, new int[] {1,2}));
+		assertArrayEquals(new int[] {0,1}, ShapeUtils.calcShapePadding(new int[] {2}, new int[] {2,1}));
+		assertArrayEquals(new int[] {1,0,1}, ShapeUtils.calcShapePadding(new int[] {2}, new int[] {1,2,1}));
+		assertArrayEquals(new int[] {-1,0}, ShapeUtils.calcShapePadding(new int[] {1,2}, new int[] {2}));
+		assertArrayEquals(new int[] {-1,0,1}, ShapeUtils.calcShapePadding(new int[] {1,2}, new int[] {2,1}));
+		assertArrayEquals(new int[] {0,0,1}, ShapeUtils.calcShapePadding(new int[] {1,2}, new int[] {1,2,1}));
+		assertArrayEquals(new int[] {0,-1}, ShapeUtils.calcShapePadding(new int[] {2,1}, new int[] {2}));
+		assertArrayEquals(new int[] {1,0,0}, ShapeUtils.calcShapePadding(new int[] {2,1}, new int[] {1,2,1}));
+		assertArrayEquals(new int[] {1,0,-1}, ShapeUtils.calcShapePadding(new int[] {2,1}, new int[] {1,2}));
+		assertArrayEquals(new int[] {-1,0,-1}, ShapeUtils.calcShapePadding(new int[] {1,2,1}, new int[] {2}));
+
+		assertArrayEquals(new int[] {1,0,0}, ShapeUtils.calcShapePadding(new int[] {2,3}, new int[] {1,2,3}));
+		assertArrayEquals(new int[] {0,1,0}, ShapeUtils.calcShapePadding(new int[] {2,3}, new int[] {2,1,3}));
+		assertArrayEquals(new int[] {0,0,1}, ShapeUtils.calcShapePadding(new int[] {2,3}, new int[] {2,3,1}));
+
+		assertArrayEquals(new int[] {1,0,0,0}, ShapeUtils.calcShapePadding(new int[] {2,1,3}, new int[] {1,2,1,3}));
+		assertArrayEquals(new int[] {0,0,1,0}, ShapeUtils.calcShapePadding(new int[] {2,1,3}, new int[] {2,1,1,3}));
+		assertArrayEquals(new int[] {0,0,0,1}, ShapeUtils.calcShapePadding(new int[] {2,1,3}, new int[] {2,1,3,1}));
+
+		assertArrayEquals(new int[] {1,0,-1,0}, ShapeUtils.calcShapePadding(new int[] {2,1,3}, new int[] {1,2,3}));
+		assertArrayEquals(new int[] {0,-1,0}, ShapeUtils.calcShapePadding(new int[] {2,1,3}, new int[] {2,3}));
+		assertArrayEquals(new int[] {0,-1,0,1}, ShapeUtils.calcShapePadding(new int[] {2,1,3}, new int[] {2,3,1}));
+
+		assertArrayEquals(new int[] {1,0,0,-1,0}, ShapeUtils.calcShapePadding(new int[] {2,1,1,3}, new int[] {1,2,1,3}));
+		assertArrayEquals(new int[] {0,0,-1,0}, ShapeUtils.calcShapePadding(new int[] {2,1,1,3}, new int[] {2,1,3}));
+		assertArrayEquals(new int[] {0,-2,0,1}, ShapeUtils.calcShapePadding(new int[] {2,1,1,3}, new int[] {2,3,1}));
+	}
+
+	@Test
+	public void testPadding() {
+		testPadding(new int[] {}, new int[] {});
+
+		testPadding(new int[] {2}, new int[] {2});
+		testPadding(new int[] {2}, new int[] {2, 1});
+		testPadding(new int[] {1, 2}, new int[] {2});
+		testPadding(new int[] {1, 2}, new int[] {2, 1});
+		testPadding(new int[] {1, 2}, new int[] {1, 2, 1});
+		testPadding(new int[] {2, 1}, new int[] {2});
+		testPadding(new int[] {2, 1}, new int[] {1, 2});
+		testPadding(new int[] {2, 1}, new int[] {1, 2, 1});
+
+		testPadding(new int[] {2, 3}, new int[] {2, 3});
+		testPadding(new int[] {2, 3}, new int[] {2, 1, 3});
+		testPadding(new int[] {1, 2, 3}, new int[] {2, 3});
+		testPadding(new int[] {1, 2, 3}, new int[] {2, 1, 3});
+		testPadding(new int[] {1, 2, 3}, new int[] {1, 2, 1, 3});
+		testPadding(new int[] {2, 3, 1}, new int[] {2, 3});
+		testPadding(new int[] {2, 3, 1}, new int[] {1, 2, 3});
+		testPadding(new int[] {2, 3, 1}, new int[] {1, 2, 1, 3});
+
+		testPadding(new int[] {2, 3}, new int[] {2, 3});
+		testPadding(new int[] {2, 3}, new int[] {2, 1, 3});
+		testPadding(new int[] {1, 2, 3}, new int[] {2, 3});
+		testPadding(new int[] {1, 2, 3}, new int[] {2, 1, 3});
+		testPadding(new int[] {1, 2, 3}, new int[] {1, 2, 1, 3});
+		testPadding(new int[] {2, 3, 1}, new int[] {2, 3});
+		testPadding(new int[] {2, 3, 1}, new int[] {1, 2, 3});
+		testPadding(new int[] {2, 3, 1}, new int[] {1, 2, 1, 3});
+	}
+
+	void testPadding(int[] a, int[] b) {
+		int[] p = ShapeUtils.calcShapePadding(a, b);
+		assertArrayEquals(b, ShapeUtils.padShape(p, b.length, a));
+
+		p = ShapeUtils.calcShapePadding(b, a);
+		assertArrayEquals(a, ShapeUtils.padShape(p, a.length, b));
 	}
 }

--- a/org.eclipse.january.test/src/org/eclipse/january/metadata/internal/AxesMetadataTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/metadata/internal/AxesMetadataTest.java
@@ -120,7 +120,7 @@ public class AxesMetadataTest {
 	@Test
 	public void testAxesMetadataReshape() throws MetadataException {
 		final int[] shape = new int[] { 1, 2, 3, 1 };
-		final int[] reshape = new int[] { 1, 1, 2, 3, 1 };
+		final int[] reshape = new int[] { 1, 1, 2, 1, 3, 1 };
 
 		int r = shape.length;
 		int[] nShape = new int[r];
@@ -154,12 +154,12 @@ public class AxesMetadataTest {
 		IDataset d = v.getSlice(new Slice(1), null);
 		assertEquals(2, d.getMetadata(AxesMetadata.class).get(0).getAxes().length);
 
-		final int[] reshape = new int[] { 1, 1, 2, 3, 1 };
+		final int[] reshape = new int[] { 1, 1, 2, 1, 3, 1 };
 		v.setShape(reshape);
-		assertEquals(5, v.getMetadata(AxesMetadata.class).get(0).getAxes().length);
+		assertEquals(6, v.getMetadata(AxesMetadata.class).get(0).getAxes().length);
 
 		d = v.getSlice((Slice) null, null, new Slice(1));
-		assertEquals(5, d.getMetadata(AxesMetadata.class).get(0).getAxes().length);
+		assertEquals(6, d.getMetadata(AxesMetadata.class).get(0).getAxes().length);
 	}
 
 	@Test

--- a/org.eclipse.january/.settings/.api_filters
+++ b/org.eclipse.january/.settings/.api_filters
@@ -82,6 +82,44 @@
             </message_arguments>
         </filter>
     </resource>
+    <resource path="src/org/eclipse/january/dataset/LazyDataset.java" type="org.eclipse.january.dataset.LazyDataset">
+        <filter id="336658481">
+            <message_arguments>
+                <message_argument value="org.eclipse.january.dataset.LazyDataset"/>
+                <message_argument value="padding"/>
+            </message_arguments>
+        </filter>
+        <filter id="336658481">
+            <message_arguments>
+                <message_argument value="org.eclipse.january.dataset.LazyDataset"/>
+                <message_argument value="sShape"/>
+            </message_arguments>
+        </filter>
+        <filter id="338755678">
+            <message_arguments>
+                <message_argument value="org.eclipse.january.dataset.LazyDataset"/>
+                <message_argument value="base"/>
+            </message_arguments>
+        </filter>
+        <filter id="338755678">
+            <message_arguments>
+                <message_argument value="org.eclipse.january.dataset.LazyDataset"/>
+                <message_argument value="postShape"/>
+            </message_arguments>
+        </filter>
+        <filter id="338755678">
+            <message_arguments>
+                <message_argument value="org.eclipse.january.dataset.LazyDataset"/>
+                <message_argument value="prepShape"/>
+            </message_arguments>
+        </filter>
+        <filter id="338792546">
+            <message_arguments>
+                <message_argument value="org.eclipse.january.dataset.LazyDataset"/>
+                <message_argument value="transformInput(IDataset)"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="src/org/eclipse/january/dataset/Maths.java" type="org.eclipse.january.dataset.Maths">
         <filter id="338849923">
             <message_arguments>

--- a/org.eclipse.january/src/org/eclipse/january/dataset/LazyDynamicDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/LazyDynamicDataset.java
@@ -89,7 +89,6 @@ public class LazyDynamicDataset extends LazyDataset implements IDynamicDataset {
 		result = prime * result + ((checker == null) ? 0 : checker.hashCode());
 		result = prime * result + ((checkingThread == null) ? 0 : checkingThread.hashCode());
 		result = prime * result + Arrays.hashCode(maxShape);
-//		result = prime * result + (stop ? 1231 : 1237);
 		return result;
 	}
 
@@ -150,12 +149,9 @@ public class LazyDynamicDataset extends LazyDataset implements IDynamicDataset {
 		}
 		return false;
 	}
-	
+
 	@Override
 	public boolean resize(int... newShape) {
-		if (base != null) {
-			throw new UnsupportedOperationException("Changing the shape of a view is not allowed");
-		}
 		int rank = shape.length;
 		if (newShape.length != rank) {
 			throw new IllegalArgumentException("Rank of new shape must match current shape");

--- a/org.eclipse.january/src/org/eclipse/january/dataset/Slice.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/Slice.java
@@ -142,11 +142,17 @@ public class Slice implements Cloneable, Serializable {
 	 * @return The Slice which the method is called on
 	 */
 	public Slice setLength(int length) {
-		if (stop != null && step > 0 && length < stop) {
-			throw new IllegalArgumentException("Length must be greater than or equal to stop");
+		if (stop != null) {
+			if (step > 0) {
+				if (length < stop) {
+					throw new IllegalArgumentException("Length must be greater than or equal to stop");
+				}
+			}
 		}
-		if (start != null && step < 0 && length < start) {
-			throw new IllegalArgumentException("Length must be greater than or equal to start");
+		if (start != null) {
+			if (start >= length) {
+				throw new IllegalArgumentException("Start must be greater than or equal to start");
+			}
 		}
 		this.length = length;
 		return this;


### PR DESCRIPTION
Clarify in code that internal operations always happens to given order, allow intermediate unit dimensions to be added, extend tests to all combinations of operations