### PR TITLE
Fix zero-sized dataset statistics

### DIFF
--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/CompoundDoubleDatasetTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/CompoundDoubleDatasetTest.java
@@ -15,6 +15,7 @@ package org.eclipse.january.dataset;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import org.eclipse.january.asserts.TestUtils;
@@ -240,6 +241,29 @@ public class CompoundDoubleDatasetTest {
 		assertEquals(Math.sqrt(1242.5), a.rootMeanSquare(), 1e-10);
 
 		assertArrayEquals(new double[] {33, 34, 35}, a.maxItem(), 1e-10);
+
+		// invalid slice view check
+		CompoundDataset v = a.getSliceView(new Slice(14, 24));
+		try {
+			v.max();
+			fail("Should have thrown exception");
+		} catch (UnsupportedOperationException e) {
+			// do nothing
+		} catch (Exception e) {
+			fail("Unexpected exception");
+		}
+		try {
+			v.minPos();
+			fail("Should have thrown exception");
+		} catch (UnsupportedOperationException e) {
+			// do nothing
+		} catch (Exception e) {
+			fail("Unexpected exception");
+		}
+		assertArrayEquals(new double[3], (double[]) v.sum(), 1e-10);
+		for (double x : (double[]) v.mean()) {
+			assertTrue(Double.isNaN(x));
+		}
 
 		a.setShape(3, 1, 4);
 		CompoundDataset b = a.sum(0);

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/DoubleDatasetTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/DoubleDatasetTest.java
@@ -12,6 +12,7 @@ package org.eclipse.january.dataset;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import org.apache.commons.math3.complex.Complex;
@@ -237,6 +238,27 @@ public class DoubleDatasetTest {
 		assertEquals(5.5, ((Number) a.mean()).doubleValue(), 1e-6);
 		assertEquals(3.6055512754639891, a.stdDeviation(), 1e-6);
 		assertEquals(13., a.variance(), 1e-6);
+
+		// invalid slice view check
+		Dataset v = a.getSliceView(new Slice(14, 24));
+		try {
+			v.max();
+			fail("Should have thrown exception");
+		} catch (UnsupportedOperationException e) {
+			// do nothing
+		} catch (Exception e) {
+			fail("Unexpected exception");
+		}
+		try {
+			v.minPos();
+			fail("Should have thrown exception");
+		} catch (UnsupportedOperationException e) {
+			// do nothing
+		} catch (Exception e) {
+			fail("Unexpected exception");
+		}
+		assertEquals(0., ((Number) v.sum()).doubleValue(), 1e-6);
+		assertTrue(Double.isNaN(((Number) v.mean()).doubleValue()));
 
 		a.setShape(3, 1, 4);
 		Dataset b = a.sum(0);

--- a/org.eclipse.january/src/org/eclipse/january/metadata/internal/StatisticsMetadataImpl.java
+++ b/org.eclipse.january/src/org/eclipse/january/metadata/internal/StatisticsMetadataImpl.java
@@ -166,6 +166,15 @@ public class StatisticsMetadataImpl<T> implements StatisticsMetadata<T> {
 	 */
 	@SuppressWarnings("unchecked")
 	private void setMaxMinSum(final MaxMin<T> mm, final boolean ignoreNaNs, final boolean ignoreInfs) {
+		if (dataset.getSize() == 0) {
+			mm.maximum = null;
+			mm.minimum = null;
+			mm.sum = (T) (isize == 1 ? InterfaceUtils.fromDoubleToBiggestNumber(clazz, 0) : null);
+			mm.maximumPositions = null;
+			mm.minimumPositions = null;
+			return;
+		}
+
 		final IndexIterator iter = dataset.getIterator();
 
 		if (!InterfaceUtils.isNumerical(clazz)) { // TODO FIXME for strings
@@ -431,7 +440,11 @@ public class StatisticsMetadataImpl<T> implements StatisticsMetadata<T> {
 	@Override
 	public T getMaximum(boolean... ignoreInvalids) {
 		int idx = refresh(isize == 1, ignoreInvalids);
-		return mms[idx].maximum;
+		T t = mms[idx].maximum;
+		if (t == null) {
+			throw new UnsupportedOperationException("Cannot operate on zero-sized dataset");
+		}
+		return t;
 	}
 
 	@Override
@@ -465,7 +478,11 @@ public class StatisticsMetadataImpl<T> implements StatisticsMetadata<T> {
 	@Override
 	public T getMinimum(boolean... ignoreInvalids) {
 		int idx = refresh(isize == 1, ignoreInvalids);
-		return mms[idx].minimum;
+		T t = mms[idx].minimum;
+		if (t == null) {
+			throw new UnsupportedOperationException("Cannot operate on zero-sized dataset");
+		}
+		return t;
 	}
 
 	@Override


### PR DESCRIPTION
When a zero-sized dataset is created then calling maxPos/minPos throws an index out of bounds exception. It is less puzzling for callers to throw an unsupported operation exception for max/min and maxPos/minPos in this case.