### PR TITLE
Fix null shape bugs

### DIFF
--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/BroadcastIteratorTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/BroadcastIteratorTest.java
@@ -18,6 +18,10 @@ public class BroadcastIteratorTest {
 	@Test
 	public void testBroadcastShape() {
 		Dataset a;
+
+		a = DatasetFactory.ones((int[]) null);
+		checkBroadcastShape(a, "null as null", null, null);
+		
 		a = DatasetFactory.ones();
 		checkBroadcastShape(a, "scalar as scalar", new int[0], new int[0]);
 		checkBroadcastShape(a, "scalar as [1]", new int[] {1}, new int[] {1}, 1);
@@ -312,5 +316,19 @@ public class BroadcastIteratorTest {
 			assertEquals(a.getElementDoubleAbs(bit.aIndex), bit.aDouble, 1e-9);
 			assertEquals(a.getElementDoubleAbs(bit.aIndex), bit.bDouble, 1e-9);
 		}
+	}
+
+	@Test
+	public void testNullDataset() {
+		DoubleDataset a = DatasetFactory.zeros((int[]) null);
+		ShortDataset b = DatasetFactory.zeros(ShortDataset.class, null);
+
+		BroadcastIterator bit;
+		bit = BroadcastIterator.createIterator(a, b);
+		assertFalse(bit.hasNext());
+
+		bit = BroadcastIterator.createIterator(a, b, null, true);
+		assertFalse(bit.hasNext());
+		assertNull(bit.getOutput().getShapeRef());
 	}
 }

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/BroadcastUtilsTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/BroadcastUtilsTest.java
@@ -9,12 +9,11 @@
 
 package org.eclipse.january.dataset;
 
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertNull;
+
 import java.util.List;
 
-import org.eclipse.january.dataset.BroadcastUtils;
-import org.eclipse.january.dataset.Dataset;
-import org.eclipse.january.dataset.DatasetFactory;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class BroadcastUtilsTest {
@@ -29,6 +28,16 @@ public class BroadcastUtilsTest {
 		view.setShape(nShapes.get(0));
 		int[] strides = BroadcastUtils.createBroadcastStrides(view, mShape);
 
-		Assert.assertArrayEquals(new int[] {0,  1}, strides);
+		assertArrayEquals(new int[] {0,  1}, strides);
+	}
+
+	@Test
+	public void testBroadcastNullShape() {
+		int[] shape = null;
+		Dataset view = DatasetFactory.zeros(ByteDataset.class, shape);
+		List<int[]> nShapes = BroadcastUtils.broadcastShapesToMax(null, shape);
+		view.setShape(nShapes.get(0));
+		int[] strides = BroadcastUtils.createBroadcastStrides(view, null);
+		assertNull(strides);
 	}
 }

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/ComparisonsTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/ComparisonsTest.java
@@ -10,6 +10,9 @@
 package org.eclipse.january.dataset;
 
 import java.util.List;
+
+import static org.junit.Assert.assertNull;
+
 import java.util.ArrayList;
 
 import org.eclipse.january.asserts.TestUtils;
@@ -69,6 +72,10 @@ public class ComparisonsTest {
 		TestUtils.assertDatasetEquals(DatasetFactory.createFromObject(new boolean[] {false, false, false, true}), c);
 		c = Comparisons.equalTo(2.5, z);
 		TestUtils.assertDatasetEquals(DatasetFactory.createFromObject(new boolean[] {false, false, false, true}), c);
+
+		// test null dataset
+		c = Comparisons.equalTo(DatasetFactory.zeros((int[]) null), DatasetFactory.zeros(ShortDataset.class, null));
+		assertNull(c.getShapeRef());
 	}
 
 	@Test

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/DatasetFactoryTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/DatasetFactoryTest.java
@@ -32,27 +32,27 @@ public class DatasetFactoryTest {
 		// zero-sized
 		exp = new DoubleDataset();
 		act = DatasetFactory.zeros(DoubleDataset.class, null);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		// zero-ranked (unit size)
 		exp = new DoubleDataset(new int[0]);
 		act = DatasetFactory.zeros(DoubleDataset.class);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		// one dimensional
 		exp = new DoubleDataset(3);
 		act = DatasetFactory.zeros(DoubleDataset.class, 3);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		// two dimensional
 		exp = new DoubleDataset(0, 0);
 		act = DatasetFactory.zeros(DoubleDataset.class, 0, 0);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		// three dimensional
 		exp = new DoubleDataset(3, 4, 5);
 		act = DatasetFactory.zeros(DoubleDataset.class, 3, 4, 5);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 	}
 
 	@Test
@@ -62,22 +62,22 @@ public class DatasetFactoryTest {
 		// zero-sized
 		exp = new DoubleDataset();
 		act = DatasetFactory.zeros(1, DoubleDataset.class, null);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		// zero-ranked (unit size)
 		exp = new DoubleDataset(new int[0]);
 		act = DatasetFactory.zeros(1, DoubleDataset.class);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		// one dimensional
 		exp = new DoubleDataset(3);
 		act = DatasetFactory.zeros(1, DoubleDataset.class, 3);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		// three dimensional
 		exp = new DoubleDataset(3, 4, 5);
 		act = DatasetFactory.zeros(1, DoubleDataset.class, 3, 4, 5);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 	}
 
 	@Test
@@ -87,42 +87,42 @@ public class DatasetFactoryTest {
 		// zero-sized
 		exp = new CompoundDoubleDataset();
 		act = DatasetFactory.zeros(0, CompoundDoubleDataset.class, null);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		exp = new CompoundDoubleDataset(1);
 		act = DatasetFactory.compoundZeros(1, CompoundDoubleDataset.class, null);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		exp = new CompoundDoubleDataset(2);
 		act = DatasetFactory.zeros(2, CompoundDoubleDataset.class, null);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		// zero-ranked (unit size)
 		exp = new CompoundDoubleDataset(1, new int[0]);
 		act = DatasetFactory.compoundZeros(1, CompoundDoubleDataset.class);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		exp = new CompoundDoubleDataset(2, new int[0]);
 		act = DatasetFactory.zeros(2, CompoundDoubleDataset.class);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		// one dimensional
 		exp = new CompoundDoubleDataset(1, new int[] {3});
 		act = DatasetFactory.compoundZeros(1, CompoundDoubleDataset.class, 3);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		exp = new CompoundDoubleDataset(2, new int[] {3});
 		act = DatasetFactory.zeros(2, CompoundDoubleDataset.class, 3);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		// three dimensional
 		exp = new CompoundDoubleDataset(1, new int[] {3, 4, 5});
 		act = DatasetFactory.compoundZeros(1, CompoundDoubleDataset.class, 3, 4, 5);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		exp = new CompoundDoubleDataset(2, new int[] {3, 4, 5});
 		act = DatasetFactory.zeros(2, CompoundDoubleDataset.class, 3, 4, 5);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 	}
 
 	@Test
@@ -133,47 +133,47 @@ public class DatasetFactoryTest {
 		exp = new DoubleDataset();
 
 		act = DatasetFactory.createFromObject(DoubleDataset.class, (Object) null);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		act = DatasetFactory.createFromObject(DoubleDataset.class, null, null);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		act = DatasetFactory.createFromObject(DoubleDataset.class, new double[0], null);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		act = DatasetFactory.createFromObject(DoubleDataset.class, new double[0]);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		act = DatasetFactory.createFromObject(DoubleDataset.class, null, 0);
-		assertEquals(exp.reshape(0), act);
+		TestUtils.assertDatasetEquals(exp.reshape(0), act);
 
 		act = DatasetFactory.createFromObject(DoubleDataset.class, new double[0], 0);
-		assertEquals(exp.reshape(0), act);
+		TestUtils.assertDatasetEquals(exp.reshape(0), act);
 
 		act = DatasetFactory.createFromObject(DoubleDataset.class, new double[0], 0, 0, 0);
-		assertEquals(exp.reshape(0, 0, 0), act);
+		TestUtils.assertDatasetEquals(exp.reshape(0, 0, 0), act);
 
 		act = DatasetFactory.createFromObject(DoubleDataset.class, new double[0], 0, 1, 0);
-		assertEquals(exp.reshape(0, 1, 0), act);
+		TestUtils.assertDatasetEquals(exp.reshape(0, 1, 0), act);
 
 		// zero-ranked (unit size)
 		exp = new DoubleDataset(new double[] {3});
 		exp.setShape();
 		act = DatasetFactory.createFromObject(DoubleDataset.class, (Object) 3);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		// one dimensional
 		exp = new DoubleDataset(new double[] { 3, 4, 5 });
 		act = DatasetFactory.createFromObject(DoubleDataset.class, new double[] { 3, 4, 5 });
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		// two dimensional
 		exp = new DoubleDataset(new double[] {3, 4, 5, 6, 7, 8}, 2, 3);
 		act = DatasetFactory.createFromObject(DoubleDataset.class, new double[] {3, 4, 5, 6, 7, 8}, 2, 3);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		act = DatasetFactory.createFromObject(DoubleDataset.class, new double[][] {{3, 4, 5}, {6, 7, 8}});
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 	}
 
 	@Test
@@ -183,29 +183,29 @@ public class DatasetFactoryTest {
 		// zero-sized
 		exp = new IntegerDataset();
 		act = DatasetFactory.createFromObject(IntegerDataset.class, null, null);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		act = DatasetFactory.createFromObject(IntegerDataset.class, new int[0], null);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		// zero-ranked (unit size)
 		exp = new IntegerDataset(new int[] {3}, null);
 		exp.setShape();
 		act = DatasetFactory.createFromObject(IntegerDataset.class, (Object) 3);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		// one dimensional
 		exp = new IntegerDataset(new int[] { 3, 4, 5 }, null);
 		act = DatasetFactory.createFromObject(IntegerDataset.class, new int[] { 3, 4, 5 }, null);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		// two dimensional
 		exp = new IntegerDataset(new int[] {3, 4, 5, 6, 7, 8}, 2, 3);
 		act = DatasetFactory.createFromObject(IntegerDataset.class, new int[] {3, 4, 5, 6, 7, 8}, 2, 3);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		act = DatasetFactory.createFromObject(IntegerDataset.class, new int[][] {{3, 4, 5}, {6, 7, 8}});
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 	}
 
 	@Test
@@ -215,23 +215,23 @@ public class DatasetFactoryTest {
 		// zero-sized
 		exp = new DoubleDataset();
 		act = DatasetFactory.createFromObject(1, DoubleDataset.class, null, null);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		// zero-ranked (unit size)
 		exp = new DoubleDataset(new double[] {3});
 		exp.setShape();
 		act = DatasetFactory.createFromObject(1, DoubleDataset.class, (Object) 3);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		// one dimensional
 		exp = new DoubleDataset(new double[] { 3, 4, 5 });
 		act = DatasetFactory.createFromObject(1, DoubleDataset.class, new double[] { 3, 4, 5 });
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		// two dimensional
 		exp = new DoubleDataset(new double[] {3, 4, 5, 6, 7, 8}, 2, 3);
 		act = DatasetFactory.createFromObject(1, DoubleDataset.class, new double[] {3, 4, 5, 6, 7, 8}, 2, 3);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 	}
 
 	@Test
@@ -241,42 +241,42 @@ public class DatasetFactoryTest {
 		// zero-sized
 		exp = new CompoundDoubleDataset();
 		act = DatasetFactory.createFromObject(0, CompoundDoubleDataset.class, null, null);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		exp = new CompoundDoubleDataset(1);
 		act = DatasetFactory.createFromObject(1, CompoundDoubleDataset.class, null, null);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		exp = new CompoundDoubleDataset(2);
 		act = DatasetFactory.createFromObject(2, CompoundDoubleDataset.class, null, null);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		// zero-ranked (unit size)
 		exp = new CompoundDoubleDataset(1, new double[] {3}, new int[0]);
 		act = DatasetFactory.createFromObject(1, CompoundDoubleDataset.class, 3.);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		exp = new CompoundDoubleDataset(2, new double[] {3, 4}, new int[0]);
 		act = DatasetFactory.createFromObject(2, CompoundDoubleDataset.class, new double[] {3, 4});
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		// one dimensional
 		exp = new CompoundDoubleDataset(1, new double[] {3, 4, 5, 6});
 		act = DatasetFactory.createFromObject(1, CompoundDoubleDataset.class, new double[] {3, 4, 5, 6});
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		exp = new CompoundDoubleDataset(2, new double[] {3, 4, 5, 6});
 		act = DatasetFactory.createFromObject(2, CompoundDoubleDataset.class, new double[] {3, 4, 5, 6});
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		// two dimensional
 		exp = new CompoundDoubleDataset(1, new double[] {3, 5, 7}, new int[] {3, 1});
 		act = DatasetFactory.createFromObject(1, CompoundDoubleDataset.class, new double[] {3, 5, 7}, 3, 1);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		exp = new CompoundDoubleDataset(2, new double[] {3, 4, 5, 6, 7, 8}, new int[] {3, 1});
 		act = DatasetFactory.createFromObject(2, CompoundDoubleDataset.class, new double[] {3, 4, 5, 6, 7, 8}, 3, 1);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 	}
 
 	@Test
@@ -286,27 +286,27 @@ public class DatasetFactoryTest {
 		// zero-sized
 		exp = new RGBDataset();
 		act = DatasetFactory.createFromObject(0, RGBDataset.class, null, null);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		// zero-ranked (unit size)
 		exp = new RGBDataset(new short[] {3, 4, 5}, new int[0]);
 		act = DatasetFactory.createFromObject(2, RGBDataset.class, new short[] {3, 4, 5});
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		// one dimensional
 		exp = new RGBDataset(new short[] {3, 4, 5, 6, 7, 8});
 		act = DatasetFactory.createFromObject(2, RGBDataset.class, new short[] {3, 4, 5, 6, 7, 8});
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		// two dimensional
 		exp = new RGBDataset(new short[] {3, 4, 5, 6, 7, 8, 9, 0, 1}, new int[] {3, 1});
 		act = DatasetFactory.createFromObject(2, RGBDataset.class, new short[] {3, 4, 5, 6, 7, 8, 9, 0, 1}, 3, 1);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		// one dimensional
 		exp = new RGBDataset(new short[] {3, 4, 5, 6, 7, 8});
 		act = DatasetFactory.createFromObject(RGBDataset.class, new short[] {3, 4, 5, 6, 7, 8});
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 	}
 
 	@Test
@@ -317,17 +317,17 @@ public class DatasetFactoryTest {
 		assertArrayEquals(new int[] {3, 5, 2}, act.getShapeRef());
 		Dataset b = a.reshape(1, 5, 2);
 		Dataset exp = DatasetUtils.concatenate(new IDataset[] {b, b, b}, 0);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		List<IDataset> list = new ArrayList<>();
 		list.add(a);
 		list.add(a);
 		list.add(a);
 		act = DatasetFactory.createFromObject(list);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		act = DatasetFactory.createFromList(list);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 	}
 
 	@Test

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/IndexIteratorTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/IndexIteratorTest.java
@@ -47,6 +47,20 @@ public class IndexIteratorTest {
 		assertFalse(it.hasNext());
 	}
 
+	@Test
+	public void testNullShapeIteration() {
+		Dataset ta = DatasetFactory.zeros((int[]) null);
+		IndexIterator it = ta.getIterator();
+
+		assertFalse(it.hasNext());
+
+		it = ta.getIterator(true);
+		assertFalse(it.hasNext());
+
+		it = new ContiguousIteratorWithPosition(null, 0);
+		assertFalse(it.hasNext());
+	}
+
 	private void testIterationsND(int size, Class<? extends Dataset> clazz) {
 		Dataset ta;
 

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/IntegersIteratorTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/IntegersIteratorTest.java
@@ -309,8 +309,12 @@ public class IntegersIteratorTest {
 
 	@Test
 	public void testZeroSizedIteration() {
-		IntegersIterator it = new IntegersIterator(new int[] {4, 0, 4});
+		IntegersIterator it;
 
+		it = new IntegersIterator(null);
+		assertFalse(it.hasNext());
+
+		it = new IntegersIterator(new int[] {4, 0, 4});
 		assertFalse(it.hasNext());
 
 		it = new IntegersIterator(new int[] {4, 4, 4}, new Slice(2, 2));

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/PositionIteratorTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/PositionIteratorTest.java
@@ -47,6 +47,13 @@ public class PositionIteratorTest {
 	}
 
 	@Test
+	public void testNullShapeIteration() {
+		PositionIterator it = new PositionIterator(null);
+
+		assertFalse(it.hasNext());
+	}
+
+	@Test
 	public void testZeroSizedIteration() {
 		PositionIterator it = new PositionIterator(new int[] {4, 0, 4});
 

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/SliceIteratorTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/SliceIteratorTest.java
@@ -33,6 +33,13 @@ public class SliceIteratorTest {
 	}
 
 	@Test
+	public void testNullShapeIteration() {
+		IndexIterator it = new SliceIterator(null, 0, (int[]) null);
+
+		assertFalse(it.hasNext());
+	}
+
+	@Test
 	public void testZeroSizedIteration() {
 		Dataset ta = DatasetFactory.createRange(24);
 		IndexIterator it = ta.getSliceIterator(null, new int[] {0}, null);

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/SliceNDIteratorTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/SliceNDIteratorTest.java
@@ -11,6 +11,7 @@ package org.eclipse.january.dataset;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 import java.util.Arrays;
 
@@ -47,9 +48,14 @@ public class SliceNDIteratorTest {
 		assertEquals(4*5, size);
 	}
 
-	/**
-	 * 
-	 */
+	@Test
+	public void testNullShapeIterations() {
+		SliceND sa = new SliceND(null);
+
+		SliceNDIterator it = new SliceNDIterator(sa);
+		assertFalse(it.hasNext());
+	}
+
 	@Test
 	public void testIterations() {
 		SliceND sa = new SliceND(new int[] {4, 5, 6, 7}, new Slice(1, 5, 2), null, null, null);

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/StrideIteratorTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/StrideIteratorTest.java
@@ -38,6 +38,13 @@ public class StrideIteratorTest {
 	}
 
 	@Test
+	public void testNullShapeIteration() {
+		StrideIterator it = new StrideIterator(null);
+
+		assertFalse(it.hasNext());
+	}
+
+	@Test
 	public void testZeroSizedIteration() {
 		Dataset ta = DatasetFactory.zeros(new int[] {4,4,4});
 

--- a/org.eclipse.january/src/org/eclipse/january/dataset/AbstractDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/AbstractDataset.java
@@ -306,9 +306,9 @@ public abstract class AbstractDataset extends LazyDatasetBase implements Dataset
 				new SingleItemIterator(offset, size)) : new StrideIterator(shape, stride, offset);
 		}
 		if (shape == null) {
-			return new NullIterator(shape, shape);
+			return new NullIterator();
 		}
-		
+
 		return withPosition ? new ContiguousIteratorWithPosition(shape, size) : new ContiguousIterator(size);
 	}
 
@@ -476,6 +476,13 @@ public abstract class AbstractDataset extends LazyDatasetBase implements Dataset
 	 * @param size
 	 */
 	private void checkShape(int[] shape, int size) {
+		if (shape == null) {
+			if (size == 0) {
+				return;
+			}
+			logger.error("New shape must not be null for nonzero-sized dataset");
+			throw new IllegalArgumentException("New shape must not be null for nonzero-sized dataset");
+		}
 		int rank = shape.length;
 		int found = -1;
 		int nsize = 1;
@@ -502,7 +509,7 @@ public abstract class AbstractDataset extends LazyDatasetBase implements Dataset
 
 	@Override
 	public void setShape(final int... shape) {
-		int[] nshape = shape.clone();
+		int[] nshape = shape == null ? null : shape.clone();
 		checkShape(nshape, size);
 		if (Arrays.equals(this.shape, nshape)) {
 			return;

--- a/org.eclipse.january/src/org/eclipse/january/dataset/ContiguousIteratorWithPosition.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/ContiguousIteratorWithPosition.java
@@ -45,10 +45,11 @@ public class ContiguousIteratorWithPosition extends IndexIterator {
 	 * @param isize number of elements in an item
 	 */
 	public ContiguousIteratorWithPosition(final int[] shape, final int length, final int isize) {
+		final int rank = shape == null ? 0 : shape.length;
 		this.shape = shape;
-		endrank = this.shape.length - 1;
+		endrank = rank - 1;
 		istep = isize;
-		if (shape.length == 0) {
+		if (rank == 0) {
 			pos = new int[0];
 		} else {
 			pos = new int[endrank + 1];
@@ -88,7 +89,7 @@ public class ContiguousIteratorWithPosition extends IndexIterator {
 
 	@Override
 	public void reset() {
-		if (shape.length > 0) {
+		if (shape != null && shape.length > 0) {
 			Arrays.fill(pos, 0);
 			pos[endrank] = -1;
 		}

--- a/org.eclipse.january/src/org/eclipse/january/dataset/IntegersIterator.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/IntegersIterator.java
@@ -55,8 +55,13 @@ public class IntegersIterator extends IndexIterator {
 	 * @param index an array of integer dataset, boolean dataset, slices or null entries (same as full slices)
 	 */
 	public IntegersIterator(final boolean restrict1D, final int[] shape, final Object... index) {
-		ishape = shape.clone();
-		irank = shape.length;
+		if (shape == null) {
+			ishape = null;
+			irank = 0;
+		}  else {
+			ishape = shape.clone();
+			irank = shape.length;
+		}
 		if (irank < index.length) {
 			throw new IllegalArgumentException("Number of index datasets is greater than rank of dataset");
 		}
@@ -166,7 +171,7 @@ public class IntegersIterator extends IndexIterator {
 			}
 		}
 		orank = oShape.size();
-		oshape = new int[orank];
+		oshape = orank == 0 && ishape == null ? null : new int[orank];
 		for (int i = 0; i < orank; i++) {
 			oshape[i] = oShape.get(i);
 		}

--- a/org.eclipse.january/src/org/eclipse/january/dataset/NullIterator.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/NullIterator.java
@@ -10,6 +10,13 @@
 package org.eclipse.january.dataset;
 
 public class NullIterator extends SliceIterator {
+
+	/**
+	 * @since 2.3
+	 */
+	public NullIterator() {
+	}
+
 	/**
 	 * @param shape shape of dataset
 	 * @param sshape shape of slice

--- a/org.eclipse.january/src/org/eclipse/january/dataset/PositionIterator.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/PositionIterator.java
@@ -121,11 +121,17 @@ public class PositionIterator extends IndexIterator {
 				throw new UnsupportedOperationException("Negative steps not implemented");
 			}
 		}
-		int rank = oshape.length;
+		int rank;
+		if (oshape == null) {
+			rank = 0;
+			shape = null;
+		} else {
+			rank = oshape.length;
+			shape = oshape.clone();
+		}
 		endrank = rank - 1;
 
 		omit = new boolean[rank];
-		shape = oshape.clone();
 		if (axes != null) {
 			for (int a : axes) {
 				a = ShapeUtils.checkAxis(rank, a);

--- a/org.eclipse.january/src/org/eclipse/january/dataset/Slice.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/Slice.java
@@ -331,7 +331,7 @@ public class Slice implements Cloneable, Serializable {
 	}
 
 	/**
-	 * Appends a String representation of the Slice comparable to the python
+	 * Append a string representation of the Slice comparable to the Python
 	 * representation.
 	 * 
 	 * @param s
@@ -381,7 +381,7 @@ public class Slice implements Cloneable, Serializable {
 	}
 
 	/**
-	 * Returns a string construction of the slice with the python form.
+	 * Returns a string construction of the slice with the Python form.
 	 * 
 	 * @return Constructed String.
 	 */
@@ -578,6 +578,8 @@ public class Slice implements Cloneable, Serializable {
 		return slice;
 	}
 
+	private static final int COLON = ':';
+
 	/**
 	 * Converts string in a Slice array
 	 * 
@@ -599,7 +601,7 @@ public class Slice implements Cloneable, Serializable {
 			Slice slice = new Slice();
 			slices[i] = slice;
 
-			int idx0 = s.indexOf(":");
+			int idx0 = s.indexOf(COLON);
 
 			int n = 0;
 			if (idx0 == -1) {
@@ -613,11 +615,12 @@ public class Slice implements Cloneable, Serializable {
 			slice.setStart(n);
 
 			idx0++;
-			int idx1 = s.indexOf(":", idx0);
+			int idx1 = s.indexOf(COLON, idx0);
 			if (idx1 == -1) {
 				String t = s.substring(idx0).trim();
-				if (t.length() == 0)
+				if (t.length() == 0) {
 					continue;
+				}
 
 				slice.setStop(Integer.parseInt(t));
 				continue;
@@ -626,8 +629,9 @@ public class Slice implements Cloneable, Serializable {
 			}
 
 			String t = s.substring(idx1 + 1).trim();
-			if (t.length() > 0)
+			if (t.length() > 0) {
 				slice.setStep(Integer.parseInt(t));
+			}
 		}
 
 		return slices;

--- a/org.eclipse.january/src/org/eclipse/january/dataset/SliceIterator.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/SliceIterator.java
@@ -177,7 +177,7 @@ public class SliceIterator extends IndexIterator {
 	public SliceIterator(final int[] shape, final int length, final int[] start, final int[] step, final int[] sshape,
 			final int isize) {
 		this.isize = isize;
-		int rank = shape.length;
+		final int rank = shape == null ? 0 : shape.length;
 		endrank = rank - 1;
 		this.shape = shape;
 		this.start = new int[rank];
@@ -232,7 +232,7 @@ public class SliceIterator extends IndexIterator {
 	 *            may be {@code null}
 	 */
 	public void setStart(int... newStart) {
-		final int rank = shape.length;
+		final int rank = shape == null ? 0 : shape.length;
 		if (rank == 0) {
 			index = -istep;
 			return;
@@ -263,7 +263,8 @@ public class SliceIterator extends IndexIterator {
 	 */
 	@Override
 	public void reset() {
-		if (shape.length == 0) {
+		final int rank = shape == null ? 0 : shape.length;
+		if (rank == 0) {
 			index = -istep;
 		} else {
 			// work out index of first position

--- a/org.eclipse.january/src/org/eclipse/january/dataset/SliceND.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/SliceND.java
@@ -28,6 +28,10 @@ public class SliceND {
 
 	private boolean expanded;
 
+	private static int[] copy(int[] in) {
+		return in == null ? null : in.clone();
+	}
+
 	/**
 	 * Construct a nD Slice for whole of shape.
 	 * 
@@ -35,13 +39,13 @@ public class SliceND {
 	 *            Shape of the dataset, see {@link ILazyDataset#getShape()}
 	 */
 	public SliceND(final int[] shape) {
-		final int rank = shape.length;
+		final int rank = shape == null ? 0 : shape.length;
 		lstart = new int[rank];
-		lstop = shape.clone();
+		lstop = copy(shape);
 		lstep = new int[rank];
 		Arrays.fill(lstep, 1);
-		lshape = shape.clone();
-		oshape = shape.clone();
+		lshape = copy(shape);
+		oshape = copy(shape);
 		mshape = oshape;
 		expanded = false;
 	}
@@ -148,8 +152,7 @@ public class SliceND {
 		//
 		// thus the final index in each dimension is
 		// start + (shape-1)*step
-
-		int rank = shape.length;
+		final int rank = shape == null ? 0 : shape.length;
 
 		if (start == null) {
 			lstart = new int[rank];
@@ -174,7 +177,7 @@ public class SliceND {
 		}
 
 		lshape = new int[rank];
-		oshape = shape.clone();
+		oshape = copy(shape);
 		if (maxShape == null) {
 			mshape = oshape;
 		} else {
@@ -505,11 +508,13 @@ public class SliceND {
 	@Override
 	public SliceND clone() {
 		SliceND c = new SliceND(oshape);
-		for (int i = 0; i < lshape.length; i++) {
-			c.lstart[i] = lstart[i];
-			c.lstop[i] = lstop[i];
-			c.lstep[i] = lstep[i];
-			c.lshape[i] = lshape[i];
+		if (lshape != null) {
+			for (int i = 0; i < lshape.length; i++) {
+				c.lstart[i] = lstart[i];
+				c.lstop[i] = lstop[i];
+				c.lstep[i] = lstep[i];
+				c.lshape[i] = lshape[i];
+			}
 		}
 		c.expanded = expanded;
 		return c;

--- a/org.eclipse.january/src/org/eclipse/january/dataset/SliceNDIterator.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/SliceNDIterator.java
@@ -55,7 +55,7 @@ public class SliceNDIterator extends IndexIterator {
 	public SliceNDIterator(SliceND slice, int... axes) {
 		cSlice = slice.clone();
 		int[] sShape = cSlice.getSourceShape();
-		shape = cSlice.getShape().clone();
+		shape = sShape == null ? null : cSlice.getShape().clone();
 		start = cSlice.getStart();
 		stop  = cSlice.getStop();
 		step  = cSlice.getStep();
@@ -64,7 +64,7 @@ public class SliceNDIterator extends IndexIterator {
 				throw new UnsupportedOperationException("Negative steps not implemented");
 			}
 		}
-		int rank = shape.length;
+		final int rank = shape == null ? 0 : shape.length;
 		endrank = rank - 1;
 
 		omit = new boolean[rank];
@@ -214,6 +214,7 @@ public class SliceNDIterator extends IndexIterator {
 
 	@Override
 	public void reset() {
+		once = false;
 		for (int i = 0, k = 0; i <= endrank; i++) {
 			int b = start[i];
 			int d = step[i];
@@ -235,7 +236,7 @@ public class SliceNDIterator extends IndexIterator {
 				break;
 		}
 		if (j > endrank) {
-			once = true;
+			once = shape != null;
 			return;
 		}
 

--- a/org.eclipse.january/src/org/eclipse/january/dataset/StrideIterator.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/StrideIterator.java
@@ -46,7 +46,7 @@ public class StrideIterator extends SliceIterator {
 	}
 
 	public StrideIterator(final int isize, final int[] shape, final int[] strides, final int offset, final int element) {
-		int rank = shape.length;
+		final int rank = shape == null ? 0 : shape.length;
 		start = new int[rank];
 		stop = shape;
 		step = new int[rank];
@@ -79,7 +79,8 @@ public class StrideIterator extends SliceIterator {
 		this.isize = isize;
 		istep = isize;
 		this.shape = shape;
-		int rank = shape.length;
+		final int rank = shape == null ? 0 : shape.length;
+		zero = shape == null;
 		endrank = rank - 1;
 		pos = new int[rank];
 		delta = new int[rank];


### PR DESCRIPTION
Zero-sized datasets return null for a shape reference but this can cause NPEs for SliceND and dataset iterators