### PR TITLE
Convert to use class specific loggers (#428)

### DIFF
--- a/org.eclipse.january.examples/src/org/eclipse/january/examples/dataset/Utils.java
+++ b/org.eclipse.january.examples/src/org/eclipse/january/examples/dataset/Utils.java
@@ -42,7 +42,7 @@ public class Utils {
 				}
 			}));
 	
-			LoggerFactory.getLogger(BasicExample.class);
+			LoggerFactory.getLogger(Utils.class);
 	
 		} finally {
 			System.setErr(saved);

--- a/org.eclipse.january/src/org/eclipse/january/dataset/AbstractCompoundDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/AbstractCompoundDataset.java
@@ -18,6 +18,8 @@ import org.eclipse.january.DatasetException;
 import org.eclipse.january.IMonitor;
 import org.eclipse.january.metadata.StatisticsMetadata;
 import org.eclipse.january.metadata.internal.StatisticsMetadataImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Generic container class for data that is compound in nature
@@ -30,6 +32,8 @@ import org.eclipse.january.metadata.internal.StatisticsMetadataImpl;
 public abstract class AbstractCompoundDataset extends AbstractDataset implements CompoundDataset {
 	// pin UID to base class
 	private static final long serialVersionUID = Dataset.serialVersionUID;
+
+	private static final Logger logger = LoggerFactory.getLogger(AbstractCompoundDataset.class);
 
 	protected int isize; // number of elements per item
 

--- a/org.eclipse.january/src/org/eclipse/january/dataset/AbstractDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/AbstractDataset.java
@@ -26,6 +26,8 @@ import org.eclipse.january.metadata.MetadataFactory;
 import org.eclipse.january.metadata.StatisticsMetadata;
 import org.eclipse.january.metadata.internal.ErrorMetadataImpl;
 import org.eclipse.january.metadata.internal.StatisticsMetadataImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Generic container class for data 
@@ -38,6 +40,8 @@ import org.eclipse.january.metadata.internal.StatisticsMetadataImpl;
 public abstract class AbstractDataset extends LazyDatasetBase implements Dataset {
 	// pin UID to base class
 	private static final long serialVersionUID = Dataset.serialVersionUID;
+
+	private static final Logger logger = LoggerFactory.getLogger(AbstractDataset.class);
 
 	protected int size; // number of items
 

--- a/org.eclipse.january/src/org/eclipse/january/dataset/BooleanDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/BooleanDataset.java
@@ -14,6 +14,9 @@ package org.eclipse.january.dataset;
 
 import java.text.MessageFormat;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 /**
  * Extend boolean base dataset for boolean values
@@ -21,6 +24,8 @@ import java.text.MessageFormat;
 public class BooleanDataset extends BooleanDatasetBase {
 	// pin UID to base class
 	private static final long serialVersionUID = Dataset.serialVersionUID;
+
+	private static final Logger logger = LoggerFactory.getLogger(BooleanDataset.class);
 
 	/**
 	 * Create a null dataset

--- a/org.eclipse.january/src/org/eclipse/january/dataset/BooleanDatasetBase.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/BooleanDatasetBase.java
@@ -21,6 +21,8 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import org.eclipse.january.metadata.StatisticsMetadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -29,6 +31,8 @@ import org.eclipse.january.metadata.StatisticsMetadata;
 public class BooleanDatasetBase extends AbstractDataset {
 	// pin UID to base class
 	private static final long serialVersionUID = Dataset.serialVersionUID;
+
+	private static final Logger logger = LoggerFactory.getLogger(BooleanDatasetBase.class);
 
 	protected boolean[] data; // subclass alias // PRIM_TYPE
 

--- a/org.eclipse.january/src/org/eclipse/january/dataset/ByteDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/ByteDataset.java
@@ -22,6 +22,8 @@ import java.util.TreeSet;
 
 import org.apache.commons.math3.complex.Complex;
 import org.eclipse.january.metadata.StatisticsMetadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -30,6 +32,8 @@ import org.eclipse.january.metadata.StatisticsMetadata;
 public class ByteDataset extends AbstractDataset {
 	// pin UID to base class
 	private static final long serialVersionUID = Dataset.serialVersionUID;
+
+	private static final Logger logger = LoggerFactory.getLogger(ByteDataset.class);
 
 	protected byte[] data; // subclass alias // PRIM_TYPE
 

--- a/org.eclipse.january/src/org/eclipse/january/dataset/ComplexDoubleDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/ComplexDoubleDataset.java
@@ -18,6 +18,8 @@ package org.eclipse.january.dataset;
 import java.util.Arrays;
 
 import org.apache.commons.math3.complex.Complex;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -26,6 +28,8 @@ import org.apache.commons.math3.complex.Complex;
 public class ComplexDoubleDataset extends CompoundDoubleDataset { // CLASS_TYPE
 	// pin UID to base class
 	private static final long serialVersionUID = Dataset.serialVersionUID;
+
+	private static final Logger logger = LoggerFactory.getLogger(ComplexDoubleDataset.class);
 
 	private static final int ISIZE = 2; // number of elements per item
 

--- a/org.eclipse.january/src/org/eclipse/january/dataset/ComplexFloatDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/ComplexFloatDataset.java
@@ -18,6 +18,8 @@ package org.eclipse.january.dataset;
 import java.util.Arrays;
 
 import org.apache.commons.math3.complex.Complex;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -26,6 +28,8 @@ import org.apache.commons.math3.complex.Complex;
 public class ComplexFloatDataset extends CompoundFloatDataset { // CLASS_TYPE
 	// pin UID to base class
 	private static final long serialVersionUID = Dataset.serialVersionUID;
+
+	private static final Logger logger = LoggerFactory.getLogger(ComplexFloatDataset.class);
 
 	private static final int ISIZE = 2; // number of elements per item
 

--- a/org.eclipse.january/src/org/eclipse/january/dataset/CompoundByteDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/CompoundByteDataset.java
@@ -17,6 +17,8 @@ package org.eclipse.january.dataset;
 import java.util.Arrays;
 
 import org.apache.commons.math3.complex.Complex;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Extend compound dataset for byte values // PRIM_TYPE
@@ -24,6 +26,8 @@ import org.apache.commons.math3.complex.Complex;
 public class CompoundByteDataset extends AbstractCompoundDataset {
 	// pin UID to base class
 	private static final long serialVersionUID = Dataset.serialVersionUID;
+
+	private static final Logger logger = LoggerFactory.getLogger(CompoundByteDataset.class);
 
 	protected byte[] data; // subclass alias // PRIM_TYPE
 

--- a/org.eclipse.january/src/org/eclipse/january/dataset/CompoundDoubleDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/CompoundDoubleDataset.java
@@ -17,6 +17,8 @@ package org.eclipse.january.dataset;
 import java.util.Arrays;
 
 import org.apache.commons.math3.complex.Complex;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Extend compound dataset for double values // PRIM_TYPE
@@ -24,6 +26,8 @@ import org.apache.commons.math3.complex.Complex;
 public class CompoundDoubleDataset extends AbstractCompoundDataset {
 	// pin UID to base class
 	private static final long serialVersionUID = Dataset.serialVersionUID;
+
+	private static final Logger logger = LoggerFactory.getLogger(CompoundDoubleDataset.class);
 
 	protected double[] data; // subclass alias // PRIM_TYPE
 

--- a/org.eclipse.january/src/org/eclipse/january/dataset/CompoundFloatDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/CompoundFloatDataset.java
@@ -17,6 +17,8 @@ package org.eclipse.january.dataset;
 import java.util.Arrays;
 
 import org.apache.commons.math3.complex.Complex;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Extend compound dataset for float values // PRIM_TYPE
@@ -24,6 +26,8 @@ import org.apache.commons.math3.complex.Complex;
 public class CompoundFloatDataset extends AbstractCompoundDataset {
 	// pin UID to base class
 	private static final long serialVersionUID = Dataset.serialVersionUID;
+
+	private static final Logger logger = LoggerFactory.getLogger(CompoundFloatDataset.class);
 
 	protected float[] data; // subclass alias // PRIM_TYPE
 

--- a/org.eclipse.january/src/org/eclipse/january/dataset/CompoundIntegerDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/CompoundIntegerDataset.java
@@ -17,6 +17,8 @@ package org.eclipse.january.dataset;
 import java.util.Arrays;
 
 import org.apache.commons.math3.complex.Complex;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Extend compound dataset for int values // PRIM_TYPE
@@ -24,6 +26,8 @@ import org.apache.commons.math3.complex.Complex;
 public class CompoundIntegerDataset extends AbstractCompoundDataset {
 	// pin UID to base class
 	private static final long serialVersionUID = Dataset.serialVersionUID;
+
+	private static final Logger logger = LoggerFactory.getLogger(CompoundIntegerDataset.class);
 
 	protected int[] data; // subclass alias // PRIM_TYPE
 

--- a/org.eclipse.january/src/org/eclipse/january/dataset/CompoundLongDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/CompoundLongDataset.java
@@ -17,6 +17,8 @@ package org.eclipse.january.dataset;
 import java.util.Arrays;
 
 import org.apache.commons.math3.complex.Complex;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Extend compound dataset for long values // PRIM_TYPE
@@ -24,6 +26,8 @@ import org.apache.commons.math3.complex.Complex;
 public class CompoundLongDataset extends AbstractCompoundDataset {
 	// pin UID to base class
 	private static final long serialVersionUID = Dataset.serialVersionUID;
+
+	private static final Logger logger = LoggerFactory.getLogger(CompoundLongDataset.class);
 
 	protected long[] data; // subclass alias // PRIM_TYPE
 

--- a/org.eclipse.january/src/org/eclipse/january/dataset/CompoundShortDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/CompoundShortDataset.java
@@ -17,6 +17,8 @@ package org.eclipse.january.dataset;
 import java.util.Arrays;
 
 import org.apache.commons.math3.complex.Complex;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Extend compound dataset for short values // PRIM_TYPE
@@ -24,6 +26,8 @@ import org.apache.commons.math3.complex.Complex;
 public class CompoundShortDataset extends AbstractCompoundDataset {
 	// pin UID to base class
 	private static final long serialVersionUID = Dataset.serialVersionUID;
+
+	private static final Logger logger = LoggerFactory.getLogger(CompoundShortDataset.class);
 
 	protected short[] data; // subclass alias // PRIM_TYPE
 

--- a/org.eclipse.january/src/org/eclipse/january/dataset/DTypeUtils.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/DTypeUtils.java
@@ -22,7 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class DTypeUtils {
-	protected static final Logger logger = LoggerFactory.getLogger(DTypeUtils.class);
+	private static final Logger logger = LoggerFactory.getLogger(DTypeUtils.class);
 
 	private static Map<Class<? extends Dataset>, Integer> createInterfaceMap() {
 		Map<Class<? extends Dataset>, Integer> map = new LinkedHashMap<>();

--- a/org.eclipse.january/src/org/eclipse/january/dataset/DatasetUtils.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/DatasetUtils.java
@@ -32,7 +32,7 @@ public class DatasetUtils {
 	/**
 	 * Setup the logging facilities
 	 */
-	transient protected static final Logger utilsLogger = LoggerFactory.getLogger(DatasetUtils.class);
+	transient private static final Logger utilsLogger = LoggerFactory.getLogger(DatasetUtils.class);
 
 	/**
 	 * Append copy of dataset with another dataset along n-th axis

--- a/org.eclipse.january/src/org/eclipse/january/dataset/DatasetUtils.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/DatasetUtils.java
@@ -32,7 +32,7 @@ public class DatasetUtils {
 	/**
 	 * Setup the logging facilities
 	 */
-	transient private static final Logger utilsLogger = LoggerFactory.getLogger(DatasetUtils.class);
+	private static final Logger utilsLogger = LoggerFactory.getLogger(DatasetUtils.class);
 
 	/**
 	 * Append copy of dataset with another dataset along n-th axis

--- a/org.eclipse.january/src/org/eclipse/january/dataset/DateDatasetImpl.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/DateDatasetImpl.java
@@ -13,9 +13,14 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class DateDatasetImpl extends StringDataset implements DateDataset {
 	// pin UID to base class
 	private static final long serialVersionUID = Dataset.serialVersionUID;
+
+	private static final Logger logger = LoggerFactory.getLogger(DateDatasetImpl.class);
 
 	private static final SimpleDateFormat ISO8601_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS");
 	

--- a/org.eclipse.january/src/org/eclipse/january/dataset/DoubleDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/DoubleDataset.java
@@ -22,6 +22,8 @@ import java.util.TreeSet;
 
 import org.apache.commons.math3.complex.Complex; // NAN_OMIT
 import org.eclipse.january.metadata.StatisticsMetadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -30,6 +32,8 @@ import org.eclipse.january.metadata.StatisticsMetadata;
 public class DoubleDataset extends AbstractDataset {
 	// pin UID to base class
 	private static final long serialVersionUID = Dataset.serialVersionUID;
+
+	private static final Logger logger = LoggerFactory.getLogger(DoubleDataset.class);
 
 	protected double[] data; // subclass alias // PRIM_TYPE
 

--- a/org.eclipse.january/src/org/eclipse/january/dataset/FloatDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/FloatDataset.java
@@ -22,6 +22,8 @@ import java.util.TreeSet;
 
 import org.apache.commons.math3.complex.Complex;
 import org.eclipse.january.metadata.StatisticsMetadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -30,6 +32,8 @@ import org.eclipse.january.metadata.StatisticsMetadata;
 public class FloatDataset extends AbstractDataset {
 	// pin UID to base class
 	private static final long serialVersionUID = Dataset.serialVersionUID;
+
+	private static final Logger logger = LoggerFactory.getLogger(FloatDataset.class);
 
 	protected float[] data; // subclass alias // PRIM_TYPE
 

--- a/org.eclipse.january/src/org/eclipse/january/dataset/IntegerDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/IntegerDataset.java
@@ -22,6 +22,8 @@ import java.util.TreeSet;
 
 import org.apache.commons.math3.complex.Complex;
 import org.eclipse.january.metadata.StatisticsMetadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -30,6 +32,8 @@ import org.eclipse.january.metadata.StatisticsMetadata;
 public class IntegerDataset extends AbstractDataset {
 	// pin UID to base class
 	private static final long serialVersionUID = Dataset.serialVersionUID;
+
+	private static final Logger logger = LoggerFactory.getLogger(IntegerDataset.class);
 
 	protected int[] data; // subclass alias // PRIM_TYPE
 

--- a/org.eclipse.january/src/org/eclipse/january/dataset/LazyDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/LazyDataset.java
@@ -33,9 +33,13 @@ import org.eclipse.january.metadata.OriginMetadata;
 import org.eclipse.january.metadata.Reshapeable;
 import org.eclipse.january.metadata.Sliceable;
 import org.eclipse.january.metadata.Transposable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class LazyDataset extends LazyDatasetBase implements Serializable, Cloneable {
 	private static final long serialVersionUID = 2467865859867440242L;
+
+	private static final Logger logger = LoggerFactory.getLogger(LazyDataset.class);
 
 	protected Map<Class<? extends MetadataType>, List<MetadataType>> oMetadata = null;
 	protected int[] oShape; // original shape

--- a/org.eclipse.january/src/org/eclipse/january/dataset/LazyDatasetBase.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/LazyDatasetBase.java
@@ -44,7 +44,7 @@ public abstract class LazyDatasetBase implements ILazyDataset, Serializable {
 
 	private static final long serialVersionUID = 767926846438976050L;
 
-	protected static final Logger logger = LoggerFactory.getLogger(LazyDatasetBase.class);
+	private static final Logger logger = LoggerFactory.getLogger(LazyDatasetBase.class);
 
 	protected static boolean catchExceptions;
 

--- a/org.eclipse.january/src/org/eclipse/january/dataset/LazyMaths.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/LazyMaths.java
@@ -31,7 +31,7 @@ public final class LazyMaths {
 	/**
 	 * Setup the logging facilities
 	 */
-	protected static final Logger logger = LoggerFactory.getLogger(LazyMaths.class);
+	private static final Logger logger = LoggerFactory.getLogger(LazyMaths.class);
 
 	// TODO Uncomment this next line when minimum JDK is set to 1.8
 	// @FunctionalInterface

--- a/org.eclipse.january/src/org/eclipse/january/dataset/LongDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/LongDataset.java
@@ -22,6 +22,8 @@ import java.util.TreeSet;
 
 import org.apache.commons.math3.complex.Complex;
 import org.eclipse.january.metadata.StatisticsMetadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -30,6 +32,8 @@ import org.eclipse.january.metadata.StatisticsMetadata;
 public class LongDataset extends AbstractDataset {
 	// pin UID to base class
 	private static final long serialVersionUID = Dataset.serialVersionUID;
+
+	private static final Logger logger = LoggerFactory.getLogger(LongDataset.class);
 
 	protected long[] data; // subclass alias // PRIM_TYPE
 

--- a/org.eclipse.january/src/org/eclipse/january/dataset/ObjectDatasetBase.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/ObjectDatasetBase.java
@@ -21,6 +21,8 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import org.eclipse.january.metadata.StatisticsMetadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -29,6 +31,8 @@ import org.eclipse.january.metadata.StatisticsMetadata;
 public class ObjectDatasetBase extends AbstractDataset {
 	// pin UID to base class
 	private static final long serialVersionUID = Dataset.serialVersionUID;
+
+	private static final Logger logger = LoggerFactory.getLogger(ObjectDatasetBase.class);
 
 	protected Object[] data; // subclass alias // PRIM_TYPE
 

--- a/org.eclipse.january/src/org/eclipse/january/dataset/RGBDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/RGBDataset.java
@@ -14,12 +14,17 @@ package org.eclipse.january.dataset;
 
 import java.util.Arrays;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Class to hold colour datasets as red, green, blue tuples of short integers
  */
 public class RGBDataset extends CompoundShortDataset implements Cloneable {
 	// pin UID to base class
 	private static final long serialVersionUID = Dataset.serialVersionUID;
+
+	private static final Logger logger = LoggerFactory.getLogger(RGBDataset.class);
 
 	private static final int ISIZE = 3; // number of elements per item
 

--- a/org.eclipse.january/src/org/eclipse/january/dataset/ShortDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/ShortDataset.java
@@ -22,6 +22,8 @@ import java.util.TreeSet;
 
 import org.apache.commons.math3.complex.Complex;
 import org.eclipse.january.metadata.StatisticsMetadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -30,6 +32,8 @@ import org.eclipse.january.metadata.StatisticsMetadata;
 public class ShortDataset extends AbstractDataset {
 	// pin UID to base class
 	private static final long serialVersionUID = Dataset.serialVersionUID;
+
+	private static final Logger logger = LoggerFactory.getLogger(ShortDataset.class);
 
 	protected short[] data; // subclass alias // PRIM_TYPE
 

--- a/org.eclipse.january/src/org/eclipse/january/dataset/StringDatasetBase.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/StringDatasetBase.java
@@ -21,6 +21,8 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import org.eclipse.january.metadata.StatisticsMetadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -29,6 +31,8 @@ import org.eclipse.january.metadata.StatisticsMetadata;
 public class StringDatasetBase extends AbstractDataset {
 	// pin UID to base class
 	private static final long serialVersionUID = Dataset.serialVersionUID;
+
+	private static final Logger logger = LoggerFactory.getLogger(StringDatasetBase.class);
 
 	protected String[] data; // subclass alias // PRIM_TYPE
 


### PR DESCRIPTION
Replace use of inherited loggers with class specific logger fields.
Fixes #428 