### PR TITLE
Update target platform 2020-06

### DIFF
--- a/GRADLE.md
+++ b/GRADLE.md
@@ -16,7 +16,7 @@ is in your repositories{} block
 
 2. Add dependency 
 ~~~~ 
-compile "org.eclipse.january:org.eclipse.january:2.2.0" 
+compile "org.eclipse.january:org.eclipse.january:2.3.0" 
 ~~~~ 
 to your file.
 

--- a/org.eclipse.january.asserts/META-INF/MANIFEST.MF
+++ b/org.eclipse.january.asserts/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse January Common Asserts (Incubation)
 Bundle-SymbolicName: org.eclipse.january.asserts;singleton:=true
-Bundle-Version: 2.3.0.qualifier
+Bundle-Version: 2.3.0
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: .
 Require-Bundle: org.junit;bundle-version="[4.12.0,5.0.0)",

--- a/org.eclipse.january.asserts/META-INF/MANIFEST.MF
+++ b/org.eclipse.january.asserts/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse January Common Asserts (Incubation)
 Bundle-SymbolicName: org.eclipse.january.asserts;singleton:=true
-Bundle-Version: 2.3.0
+Bundle-Version: 2.3.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: .
 Require-Bundle: org.junit;bundle-version="[4.12.0,5.0.0)",

--- a/org.eclipse.january.asserts/pom.xml
+++ b/org.eclipse.january.asserts/pom.xml
@@ -14,12 +14,12 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>org.eclipse.january.asserts</artifactId>
-	<version>2.3.0</version>
+	<version>2.3.1-SNAPSHOT</version>
 	<parent>
 		<relativePath>../releng/org.eclipse.january.releng/pom.xml</relativePath>
 		<groupId>org.eclipse.january</groupId>
 		<artifactId>org.eclipse.january.releng</artifactId>
-		<version>2.3.0</version>
+		<version>2.3.1-SNAPSHOT</version>
 	</parent>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/org.eclipse.january.asserts/pom.xml
+++ b/org.eclipse.january.asserts/pom.xml
@@ -14,12 +14,12 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>org.eclipse.january.asserts</artifactId>
-	<version>2.3.0-SNAPSHOT</version>
+	<version>2.3.0</version>
 	<parent>
 		<relativePath>../releng/org.eclipse.january.releng/pom.xml</relativePath>
 		<groupId>org.eclipse.january</groupId>
 		<artifactId>org.eclipse.january.releng</artifactId>
-		<version>2.3.0-SNAPSHOT</version>
+		<version>2.3.0</version>
 	</parent>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/org.eclipse.january.examples/JanuaryExamples.target
+++ b/org.eclipse.january.examples/JanuaryExamples.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/mbarbero/fr.obeo.releng.targetplatform -->
-<target name="JanuaryExamples" sequenceNumber="1568301199">
+<target name="JanuaryExamples" sequenceNumber="1641568610">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.january" version="0.0.0"/>
@@ -9,13 +9,12 @@
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="javax.measure.unit-api" version="1.0.0.v20170818-1538"/>
-      <unit id="org.apache.commons.math3" version="3.5.0.v20160301-1110"/>
-      <unit id="org.slf4j.api" version="1.7.10.v20170428-1633"/>
+      <unit id="org.apache.commons.math3" version="3.5.0.v20190611-1023"/>
+      <unit id="org.slf4j.api" version="1.7.30.v20200204-2150"/>
       <unit id="org.hamcrest.core" version="1.3.0.v20180420-1519"/>
       <unit id="org.hamcrest.library" version="1.3.0.v20180524-2246"/>
-      <unit id="org.junit" version="4.12.0.v201504281640"/>
-      <unit id="org.mockito" version="1.9.5.v201605172210"/>
-      <repository id="eclipse-orbit-photon" location="https://download.eclipse.org/tools/orbit/downloads/drops/R20180606145124/repository"/>
+      <unit id="org.junit" version="4.13.0.v20200204-1500"/>
+      <repository id="eclipse-orbit-2020-06" location="https://download.eclipse.org/tools/orbit/downloads/drops/R20200529191137/repository"/>
     </location>
   </locations>
 </target>

--- a/org.eclipse.january.examples/JanuaryExamples.target
+++ b/org.eclipse.january.examples/JanuaryExamples.target
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/mbarbero/fr.obeo.releng.targetplatform -->
-<target name="JanuaryExamples" sequenceNumber="1539763980">
+<target name="JanuaryExamples" sequenceNumber="1568276122">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.january" version="0.0.0"/>
-      <repository id="january-latest" location="http://download.eclipse.org/january/builds/january-master/latest/repository"/>
+      <repository id="january-2.3RC1" location="http://download.eclipse.org/january/releasecandidates/2.3RC1/repository"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="javax.measure.unit-api" version="1.0.0.v20170818-1538"/>

--- a/org.eclipse.january.examples/JanuaryExamples.target
+++ b/org.eclipse.january.examples/JanuaryExamples.target
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/mbarbero/fr.obeo.releng.targetplatform -->
-<target name="JanuaryExamples" sequenceNumber="1568276122">
+<target name="JanuaryExamples" sequenceNumber="1568301199">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.january" version="0.0.0"/>
-      <repository id="january-2.3RC1" location="http://download.eclipse.org/january/releasecandidates/2.3RC1/repository"/>
+      <repository id="january-2.3" location="https://download.eclipse.org/january/releases/2.3/repository"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="javax.measure.unit-api" version="1.0.0.v20170818-1538"/>
@@ -15,7 +15,7 @@
       <unit id="org.hamcrest.library" version="1.3.0.v20180524-2246"/>
       <unit id="org.junit" version="4.12.0.v201504281640"/>
       <unit id="org.mockito" version="1.9.5.v201605172210"/>
-      <repository id="eclipse-orbit-photon" location="http://download.eclipse.org/tools/orbit/downloads/drops/R20180606145124/repository"/>
+      <repository id="eclipse-orbit-photon" location="https://download.eclipse.org/tools/orbit/downloads/drops/R20180606145124/repository"/>
     </location>
   </locations>
 </target>

--- a/org.eclipse.january.examples/JanuaryExamples.tpd
+++ b/org.eclipse.january.examples/JanuaryExamples.tpd
@@ -7,11 +7,11 @@ target "JanuaryExamples" with source requirements
 // This set of examples is for the latest master branch build of January.
 // The examples are available for the released version of January on the
 // respective release branches (e.g. january_1_0 for the 1.0 release)
-location "http://download.eclipse.org/january/releasecandidates/2.3RC1/repository" january-2.3RC1 {
+location "https://download.eclipse.org/january/releases/2.3/repository" january-2.3 {
 	org.eclipse.january lazy
 }
 
-location "http://download.eclipse.org/tools/orbit/downloads/drops/R20180606145124/repository" eclipse-orbit-photon {
+location "https://download.eclipse.org/tools/orbit/downloads/drops/R20180606145124/repository" eclipse-orbit-photon {
 // Core requirements
 	javax.measure.unit-api [1.0.0]
 	org.apache.commons.math3 [3.5.0,3.5.1)

--- a/org.eclipse.january.examples/JanuaryExamples.tpd
+++ b/org.eclipse.january.examples/JanuaryExamples.tpd
@@ -11,7 +11,7 @@ location "https://download.eclipse.org/january/releases/2.3/repository" january-
 	org.eclipse.january lazy
 }
 
-location "https://download.eclipse.org/tools/orbit/downloads/drops/R20180606145124/repository" eclipse-orbit-photon {
+location "https://download.eclipse.org/tools/orbit/downloads/drops/R20200529191137/repository" eclipse-orbit-2020-06 {
 // Core requirements
 	javax.measure.unit-api [1.0.0]
 	org.apache.commons.math3 [3.5.0,3.5.1)
@@ -21,5 +21,4 @@ location "https://download.eclipse.org/tools/orbit/downloads/drops/R201806061451
 	org.hamcrest.core [1.3.0,2.0.0)
 	org.hamcrest.library [1.3.0,2.0.0)
 	org.junit [4.12.0,5.0.0)
-	org.mockito [1.9.5,2.0.0)
 }

--- a/org.eclipse.january.examples/JanuaryExamples.tpd
+++ b/org.eclipse.january.examples/JanuaryExamples.tpd
@@ -7,7 +7,7 @@ target "JanuaryExamples" with source requirements
 // This set of examples is for the latest master branch build of January.
 // The examples are available for the released version of January on the
 // respective release branches (e.g. january_1_0 for the 1.0 release)
-location "http://download.eclipse.org/january/builds/january-master/latest/repository" january-latest {
+location "http://download.eclipse.org/january/releasecandidates/2.3RC1/repository" january-2.3RC1 {
 	org.eclipse.january lazy
 }
 

--- a/org.eclipse.january.examples/META-INF/MANIFEST.MF
+++ b/org.eclipse.january.examples/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse January Examples (Incubation)
 Bundle-SymbolicName: org.eclipse.january.examples
-Bundle-Version: 2.3.0
+Bundle-Version: 2.3.1.qualifier
 Fragment-Host: org.eclipse.january;bundle-version="2.3.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.junit;bundle-version="[4.12.0,5.0.0)"

--- a/org.eclipse.january.examples/META-INF/MANIFEST.MF
+++ b/org.eclipse.january.examples/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse January Examples (Incubation)
 Bundle-SymbolicName: org.eclipse.january.examples
-Bundle-Version: 2.3.0.qualifier
+Bundle-Version: 2.3.0
 Fragment-Host: org.eclipse.january;bundle-version="2.3.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.junit;bundle-version="[4.12.0,5.0.0)"

--- a/org.eclipse.january.examples/META-INF/MANIFEST.MF
+++ b/org.eclipse.january.examples/META-INF/MANIFEST.MF
@@ -8,3 +8,4 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.junit;bundle-version="[4.12.0,5.0.0)"
 Bundle-Vendor: Eclipse January
 Automatic-Module-Name: org.eclipse.january.examples
+Import-Package: javax.annotation

--- a/org.eclipse.january.examples/pom.xml
+++ b/org.eclipse.january.examples/pom.xml
@@ -14,12 +14,12 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>org.eclipse.january.examples</artifactId>
-	<version>2.3.0-SNAPSHOT</version>
+	<version>2.3.0</version>
 	<parent>
 		<relativePath>../releng/org.eclipse.january.releng/pom.xml</relativePath>
 		<groupId>org.eclipse.january</groupId>
 		<artifactId>org.eclipse.january.releng</artifactId>
-		<version>2.3.0-SNAPSHOT</version>
+		<version>2.3.0</version>
 	</parent>
 	<packaging>eclipse-test-plugin</packaging>
 	<build>

--- a/org.eclipse.january.examples/pom.xml
+++ b/org.eclipse.january.examples/pom.xml
@@ -14,12 +14,12 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>org.eclipse.january.examples</artifactId>
-	<version>2.3.0</version>
+	<version>2.3.1-SNAPSHOT</version>
 	<parent>
 		<relativePath>../releng/org.eclipse.january.releng/pom.xml</relativePath>
 		<groupId>org.eclipse.january</groupId>
 		<artifactId>org.eclipse.january.releng</artifactId>
-		<version>2.3.0</version>
+		<version>2.3.1-SNAPSHOT</version>
 	</parent>
 	<packaging>eclipse-test-plugin</packaging>
 	<build>

--- a/org.eclipse.january.examples/src/org/eclipse/january/examples/dataset/Utils.java
+++ b/org.eclipse.january.examples/src/org/eclipse/january/examples/dataset/Utils.java
@@ -42,7 +42,7 @@ public class Utils {
 				}
 			}));
 	
-			LoggerFactory.getLogger(BasicExample.class);
+			LoggerFactory.getLogger(Utils.class);
 	
 		} finally {
 			System.setErr(saved);

--- a/org.eclipse.january.examples/src/org/eclipse/january/examples/io/LazyLoadingExample.java
+++ b/org.eclipse.january.examples/src/org/eclipse/january/examples/io/LazyLoadingExample.java
@@ -27,6 +27,7 @@ import org.eclipse.january.dataset.DatasetFactory;
 import org.eclipse.january.dataset.DatasetUtils;
 import org.eclipse.january.dataset.IDataset;
 import org.eclipse.january.dataset.ILazyDataset;
+import org.eclipse.january.dataset.IntegerDataset;
 import org.eclipse.january.dataset.LazyDataset;
 import org.eclipse.january.dataset.Slice;
 import org.eclipse.january.dataset.SliceND;
@@ -73,7 +74,7 @@ public class LazyLoadingExample {
 					return tmp.getSliceView(slice);
 				}
 			};
-			LazyDataset lazy = new LazyDataset(file.getName(), Dataset.INT32, shape, loader);
+			LazyDataset lazy = new LazyDataset(loader, file.getName(), IntegerDataset.class, shape);
 			return lazy;
 		} catch (IOException e) {
 			e.printStackTrace();

--- a/org.eclipse.january.test/META-INF/MANIFEST.MF
+++ b/org.eclipse.january.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse January Dataset Tests (Incubation)
 Bundle-SymbolicName: org.eclipse.january.test
-Bundle-Version: 2.3.0.qualifier
+Bundle-Version: 2.3.0
 Fragment-Host: org.eclipse.january;bundle-version="2.3.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.junit;bundle-version="[4.12.0,5.0.0)",

--- a/org.eclipse.january.test/META-INF/MANIFEST.MF
+++ b/org.eclipse.january.test/META-INF/MANIFEST.MF
@@ -9,3 +9,4 @@ Require-Bundle: org.junit;bundle-version="[4.12.0,5.0.0)",
  org.eclipse.january.asserts;bundle-version="2.3.0"
 Bundle-Vendor: Eclipse January
 Automatic-Module-Name: org.eclipse.january.test
+Import-Package: javax.annotation

--- a/org.eclipse.january.test/META-INF/MANIFEST.MF
+++ b/org.eclipse.january.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse January Dataset Tests (Incubation)
 Bundle-SymbolicName: org.eclipse.january.test
-Bundle-Version: 2.3.0
+Bundle-Version: 2.3.1.qualifier
 Fragment-Host: org.eclipse.january;bundle-version="2.3.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.junit;bundle-version="[4.12.0,5.0.0)",

--- a/org.eclipse.january.test/pom.xml
+++ b/org.eclipse.january.test/pom.xml
@@ -14,12 +14,12 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>org.eclipse.january.test</artifactId>
-	<version>2.3.0-SNAPSHOT</version>
+	<version>2.3.0</version>
 	<parent>
 		<relativePath>../releng/org.eclipse.january.releng/pom.xml</relativePath>
 		<groupId>org.eclipse.january</groupId>
 		<artifactId>org.eclipse.january.releng</artifactId>
-		<version>2.3.0-SNAPSHOT</version>
+		<version>2.3.0</version>
 	</parent>
 	<packaging>eclipse-test-plugin</packaging>
 </project>

--- a/org.eclipse.january.test/pom.xml
+++ b/org.eclipse.january.test/pom.xml
@@ -14,12 +14,12 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>org.eclipse.january.test</artifactId>
-	<version>2.3.0</version>
+	<version>2.3.1-SNAPSHOT</version>
 	<parent>
 		<relativePath>../releng/org.eclipse.january.releng/pom.xml</relativePath>
 		<groupId>org.eclipse.january</groupId>
 		<artifactId>org.eclipse.january.releng</artifactId>
-		<version>2.3.0</version>
+		<version>2.3.1-SNAPSHOT</version>
 	</parent>
 	<packaging>eclipse-test-plugin</packaging>
 </project>

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/AbstractDatasetTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/AbstractDatasetTest.java
@@ -1120,6 +1120,31 @@ public class AbstractDatasetTest {
 		while (is.hasNext() && it.hasNext()) {
 			assertEquals(s.getElementLongAbs(is.index), t.getElementLongAbs(it.index));
 		}
+
+		// test input SliceND checking
+		try {
+			a.getSlice(new SliceND(null));
+			fail();
+		} catch (IllegalArgumentException e) {
+			System.out.println("As expected: " + e);
+		}
+
+		try {
+			a.getSlice(new SliceND(new int[0]));
+			fail();
+		} catch (IllegalArgumentException e) {
+			System.out.println("As expected: " + e);
+		}
+
+		try {
+			a.getSlice(new SliceND(new int[2]));
+			fail();
+		} catch (IllegalArgumentException e) {
+			System.out.println("As expected: " + e);
+		}
+
+		s = a.getSlice(new SliceND(a.getShape()));
+		Assert.assertEquals("Full slice", a, s);
 	}
 
 	@Test
@@ -1165,6 +1190,32 @@ public class AbstractDatasetTest {
 		b = a.getSliceView();
 		b.setShape(1);
 		assertTrue(b.getIterator().hasNext());
+
+		// test input SliceND checking
+		a = DatasetFactory.createRange(60).reshape(6, 10);
+		try {
+			a.getSliceView(new SliceND(null));
+			fail();
+		} catch (IllegalArgumentException e) {
+			System.out.println("As expected: " + e);
+		}
+
+		try {
+			a.getSliceView(new SliceND(new int[0]));
+			fail();
+		} catch (IllegalArgumentException e) {
+			System.out.println("As expected: " + e);
+		}
+
+		try {
+			a.getSliceView(new SliceND(new int[2]));
+			fail();
+		} catch (IllegalArgumentException e) {
+			System.out.println("As expected: " + e);
+		}
+
+		b = a.getSliceView(new SliceND(a.getShape()));
+		Assert.assertEquals("Full slice", a, b);
 	}
 
 	private Dataset checkSliceView(Dataset a, int[] start, int[] stop, int[] step) {
@@ -1519,7 +1570,7 @@ public class AbstractDatasetTest {
 		assertEquals("MinPos", 0, a.minPos().length);
 		assertEquals("ArgMax", 0, a.argMax());
 		assertEquals("ArgMin", 0, a.argMin());
-		assertEquals("Value", true, a.equals(Double.valueOf(1.0)));
+		assertTrue("Value",  a.equals(Double.valueOf(1.0)));
 
 		a = DatasetFactory.zeros(ShortDataset.class);
 		assertEquals("Rank", 0, a.getRank());

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/AbstractDatasetTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/AbstractDatasetTest.java
@@ -1585,7 +1585,7 @@ public class AbstractDatasetTest {
 	@Test
 	public void testSum() {
 		Dataset a = DatasetFactory.createRange(IntegerDataset.class, 1024*1024);
-		assertEquals("Sum", -524288, a.sum());
+		assertEquals("Sum", -524288, a.sum()); // 549755289600
 
 		a = a.cast(DoubleDataset.class);
 		assertEquals("Sum", 1024*512*(1024.*1024 - 1), ((Number) a.sum()).doubleValue(), 1e-6);

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/AbstractDatasetTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/AbstractDatasetTest.java
@@ -34,10 +34,10 @@ import org.junit.Test;
 public class AbstractDatasetTest {
 	@Test
 	public void testBestDType() {
-		assertEquals(Dataset.FLOAT32, DTypeUtils.getBestDType(Dataset.INT16, Dataset.FLOAT32));
-		assertEquals(Dataset.FLOAT64, DTypeUtils.getBestDType(Dataset.INT32, Dataset.FLOAT32));
-		assertEquals(Dataset.COMPLEX64, DTypeUtils.getBestDType(Dataset.FLOAT32, Dataset.COMPLEX64));
-		assertEquals(Dataset.COMPLEX128, DTypeUtils.getBestDType(Dataset.INT32, Dataset.COMPLEX64));
+		assertEquals(FloatDataset.class, InterfaceUtils.getBestInterface(ShortDataset.class, FloatDataset.class));
+		assertEquals(DoubleDataset.class, InterfaceUtils.getBestInterface(LongDataset.class, FloatDataset.class));
+		assertEquals(ComplexFloatDataset.class, InterfaceUtils.getBestInterface(FloatDataset.class, ComplexFloatDataset.class));
+		assertEquals(ComplexDoubleDataset.class, InterfaceUtils.getBestInterface(IntegerDataset.class, ComplexFloatDataset.class));
 	}
 
 	@Test

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/BroadcastIteratorTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/BroadcastIteratorTest.java
@@ -18,6 +18,10 @@ public class BroadcastIteratorTest {
 	@Test
 	public void testBroadcastShape() {
 		Dataset a;
+
+		a = DatasetFactory.ones((int[]) null);
+		checkBroadcastShape(a, "null as null", null, null);
+		
 		a = DatasetFactory.ones();
 		checkBroadcastShape(a, "scalar as scalar", new int[0], new int[0]);
 		checkBroadcastShape(a, "scalar as [1]", new int[] {1}, new int[] {1}, 1);
@@ -312,5 +316,19 @@ public class BroadcastIteratorTest {
 			assertEquals(a.getElementDoubleAbs(bit.aIndex), bit.aDouble, 1e-9);
 			assertEquals(a.getElementDoubleAbs(bit.aIndex), bit.bDouble, 1e-9);
 		}
+	}
+
+	@Test
+	public void testNullDataset() {
+		DoubleDataset a = DatasetFactory.zeros((int[]) null);
+		ShortDataset b = DatasetFactory.zeros(ShortDataset.class, null);
+
+		BroadcastIterator bit;
+		bit = BroadcastIterator.createIterator(a, b);
+		assertFalse(bit.hasNext());
+
+		bit = BroadcastIterator.createIterator(a, b, null, true);
+		assertFalse(bit.hasNext());
+		assertNull(bit.getOutput().getShapeRef());
 	}
 }

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/BroadcastUtilsTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/BroadcastUtilsTest.java
@@ -9,12 +9,11 @@
 
 package org.eclipse.january.dataset;
 
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertNull;
+
 import java.util.List;
 
-import org.eclipse.january.dataset.BroadcastUtils;
-import org.eclipse.january.dataset.Dataset;
-import org.eclipse.january.dataset.DatasetFactory;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class BroadcastUtilsTest {
@@ -29,6 +28,16 @@ public class BroadcastUtilsTest {
 		view.setShape(nShapes.get(0));
 		int[] strides = BroadcastUtils.createBroadcastStrides(view, mShape);
 
-		Assert.assertArrayEquals(new int[] {0,  1}, strides);
+		assertArrayEquals(new int[] {0,  1}, strides);
+	}
+
+	@Test
+	public void testBroadcastNullShape() {
+		int[] shape = null;
+		Dataset view = DatasetFactory.zeros(ByteDataset.class, shape);
+		List<int[]> nShapes = BroadcastUtils.broadcastShapesToMax(null, shape);
+		view.setShape(nShapes.get(0));
+		int[] strides = BroadcastUtils.createBroadcastStrides(view, null);
+		assertNull(strides);
 	}
 }

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/ByteDatasetTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/ByteDatasetTest.java
@@ -47,7 +47,7 @@ public class ByteDatasetTest {
 	@Test
 	public void testStats() {
 		Dataset a = DatasetFactory.createRange(ByteDataset.class, 12);
-		assertEquals(11., a.max().doubleValue(), 1e-6);
+		assertEquals(Byte.valueOf((byte) 11), a.max());
 		assertEquals(0., a.min().doubleValue(), 1e-6);
 		assertEquals(5.5, ((Number) a.mean()).doubleValue(), 1e-6);
 		assertEquals(3.6055512754639891, a.stdDeviation(), 1e-6);

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/ComparisonsTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/ComparisonsTest.java
@@ -10,6 +10,9 @@
 package org.eclipse.january.dataset;
 
 import java.util.List;
+
+import static org.junit.Assert.assertNull;
+
 import java.util.ArrayList;
 
 import org.eclipse.january.asserts.TestUtils;
@@ -69,6 +72,10 @@ public class ComparisonsTest {
 		TestUtils.assertDatasetEquals(DatasetFactory.createFromObject(new boolean[] {false, false, false, true}), c);
 		c = Comparisons.equalTo(2.5, z);
 		TestUtils.assertDatasetEquals(DatasetFactory.createFromObject(new boolean[] {false, false, false, true}), c);
+
+		// test null dataset
+		c = Comparisons.equalTo(DatasetFactory.zeros((int[]) null), DatasetFactory.zeros(ShortDataset.class, null));
+		assertNull(c.getShapeRef());
 	}
 
 	@Test

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/ComplexDoubleDatasetTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/ComplexDoubleDatasetTest.java
@@ -10,17 +10,13 @@
 package org.eclipse.january.dataset;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.math3.complex.Complex;
-import org.eclipse.january.dataset.ComplexDoubleDataset;
-import org.eclipse.january.dataset.Dataset;
-import org.eclipse.january.dataset.DatasetFactory;
-import org.eclipse.january.dataset.IndexIterator;
-import org.eclipse.january.dataset.Maths;
-import org.eclipse.january.dataset.Slice;
+import org.eclipse.january.asserts.TestUtils;
 import org.junit.Test;
 
 public class ComplexDoubleDatasetTest {
@@ -32,7 +28,7 @@ public class ComplexDoubleDatasetTest {
 		double[] da = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
 		ComplexDoubleDataset a = new ComplexDoubleDataset(da);
 
-		assertEquals(Dataset.COMPLEX128, a.getDType());
+		assertTrue("Interface", ComplexDoubleDataset.class.isAssignableFrom(a.getClass()));
 		assertEquals(2, a.getElementsPerItem());
 		assertEquals(16, a.getItemBytes());
 
@@ -61,7 +57,7 @@ public class ComplexDoubleDatasetTest {
 		assertEquals(1.0, z.getComplex(0).getImaginary(), 1e-6);
 
 		Dataset aa = Maths.abs(a);
-		assertEquals(Dataset.FLOAT64, aa.getDType());
+		assertTrue("Interface", DoubleDataset.class.isAssignableFrom(aa.getClass()));
 		assertEquals(1, aa.getElementsPerItem());
 		assertEquals(8, aa.getItemBytes());
 
@@ -112,8 +108,25 @@ public class ComplexDoubleDatasetTest {
 		a.iadd(new Complex(0,0.5));
 		assertEquals(5.5, ((Complex) a.mean()).getReal(), 1e-6);
 		assertEquals(0.5, ((Complex) a.mean()).getImaginary(), 1e-6);
-//		assertEquals(13., a.var().doubleValue(), 1e-6);
-//		assertEquals(3.6055512754639891, a.std().doubleValue(), 1e-6);
+		assertEquals(13., a.variance(), 1e-6);
+		assertEquals(3.6055512754639891, a.stdDeviation(), 1e-6);
+	}
 
+	static class ComplexDoubleDataset2 extends ComplexDoubleDataset {
+		private static final long serialVersionUID = 1L;
+
+		public ComplexDoubleDataset2(final ComplexDoubleDataset dataset) {
+			super(dataset);
+		}
+	}
+
+	@Test
+	public void testSubclassing() {
+		double[] da = { 0, 0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5, 5.5,
+				6, 6.5, 7, 7.5, 8, 8.5, 9, 9.5, 10, 10.5, 11, 11.5 };
+		ComplexDoubleDataset a = new ComplexDoubleDataset(da);
+
+		ComplexDoubleDataset2 b = new ComplexDoubleDataset2(a);
+		TestUtils.assertDatasetEquals(a, b);
 	}
 }

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/ComplexFloatDatasetTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/ComplexFloatDatasetTest.java
@@ -10,6 +10,7 @@
 package org.eclipse.january.dataset;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import org.eclipse.january.dataset.ComplexFloatDataset;
 import org.eclipse.january.dataset.Dataset;
@@ -26,7 +27,7 @@ public class ComplexFloatDatasetTest {
 		float[] da = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
 		ComplexFloatDataset a = new ComplexFloatDataset(da);
 
-		assertEquals(Dataset.COMPLEX64, a.getDType());
+		assertTrue("Interface", ComplexFloatDataset.class.isAssignableFrom(a.getClass()));
 		assertEquals(2, a.getElementsPerItem());
 		assertEquals(8, a.getItemBytes());
 
@@ -43,7 +44,7 @@ public class ComplexFloatDatasetTest {
 		}
 
 		Dataset aa = Maths.abs(a);
-		assertEquals(Dataset.FLOAT32, aa.getDType());
+		assertTrue("Interface", FloatDataset.class.isAssignableFrom(aa.getClass()));
 		assertEquals(1, aa.getElementsPerItem());
 		assertEquals(4, aa.getItemBytes());		
 

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/CompoundDoubleDatasetTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/CompoundDoubleDatasetTest.java
@@ -15,6 +15,7 @@ package org.eclipse.january.dataset;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import org.eclipse.january.asserts.TestUtils;
@@ -240,6 +241,29 @@ public class CompoundDoubleDatasetTest {
 		assertEquals(Math.sqrt(1242.5), a.rootMeanSquare(), 1e-10);
 
 		assertArrayEquals(new double[] {33, 34, 35}, a.maxItem(), 1e-10);
+
+		// invalid slice view check
+		CompoundDataset v = a.getSliceView(new Slice(14, 24));
+		try {
+			v.max();
+			fail("Should have thrown exception");
+		} catch (UnsupportedOperationException e) {
+			// do nothing
+		} catch (Exception e) {
+			fail("Unexpected exception");
+		}
+		try {
+			v.minPos();
+			fail("Should have thrown exception");
+		} catch (UnsupportedOperationException e) {
+			// do nothing
+		} catch (Exception e) {
+			fail("Unexpected exception");
+		}
+		assertArrayEquals(new double[3], (double[]) v.sum(), 1e-10);
+		for (double x : (double[]) v.mean()) {
+			assertTrue(Double.isNaN(x));
+		}
 
 		a.setShape(3, 1, 4);
 		CompoundDataset b = a.sum(0);

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/CompoundDoubleDatasetTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/CompoundDoubleDatasetTest.java
@@ -19,12 +19,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import org.eclipse.january.asserts.TestUtils;
-import org.eclipse.january.dataset.Dataset;
-import org.eclipse.january.dataset.DatasetFactory;
-import org.eclipse.january.dataset.DoubleDataset;
-import org.eclipse.january.dataset.IndexIterator;
-import org.eclipse.january.dataset.Maths;
-import org.eclipse.january.dataset.Slice;
 import org.junit.Test;
 
 public class CompoundDoubleDatasetTest {
@@ -355,5 +349,23 @@ public class CompoundDoubleDatasetTest {
 			}
 			
 		}
+	}
+
+	static class CompoundDoubleDataset2 extends CompoundDoubleDataset {
+		private static final long serialVersionUID = 1L;
+
+		public CompoundDoubleDataset2(final CompoundDoubleDataset dataset) {
+			super(dataset);
+		}
+	}
+
+	@Test
+	public void testSubclassing() {
+		double[] da = { 0, 0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5, 5.5,
+				6, 6.5, 7, 7.5, 8, 8.5, 9, 9.5, 10, 10.5, 11, 11.5 };
+		CompoundDoubleDataset a = new CompoundDoubleDataset(2, da);
+
+		CompoundDoubleDataset2 b = new CompoundDoubleDataset2(a);
+		TestUtils.assertDatasetEquals(a, b);
 	}
 }

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/DatasetFactoryTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/DatasetFactoryTest.java
@@ -32,27 +32,27 @@ public class DatasetFactoryTest {
 		// zero-sized
 		exp = new DoubleDataset();
 		act = DatasetFactory.zeros(DoubleDataset.class, null);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		// zero-ranked (unit size)
 		exp = new DoubleDataset(new int[0]);
 		act = DatasetFactory.zeros(DoubleDataset.class);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		// one dimensional
 		exp = new DoubleDataset(3);
 		act = DatasetFactory.zeros(DoubleDataset.class, 3);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		// two dimensional
 		exp = new DoubleDataset(0, 0);
 		act = DatasetFactory.zeros(DoubleDataset.class, 0, 0);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		// three dimensional
 		exp = new DoubleDataset(3, 4, 5);
 		act = DatasetFactory.zeros(DoubleDataset.class, 3, 4, 5);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 	}
 
 	@Test
@@ -62,22 +62,22 @@ public class DatasetFactoryTest {
 		// zero-sized
 		exp = new DoubleDataset();
 		act = DatasetFactory.zeros(1, DoubleDataset.class, null);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		// zero-ranked (unit size)
 		exp = new DoubleDataset(new int[0]);
 		act = DatasetFactory.zeros(1, DoubleDataset.class);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		// one dimensional
 		exp = new DoubleDataset(3);
 		act = DatasetFactory.zeros(1, DoubleDataset.class, 3);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		// three dimensional
 		exp = new DoubleDataset(3, 4, 5);
 		act = DatasetFactory.zeros(1, DoubleDataset.class, 3, 4, 5);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 	}
 
 	@Test
@@ -87,42 +87,42 @@ public class DatasetFactoryTest {
 		// zero-sized
 		exp = new CompoundDoubleDataset();
 		act = DatasetFactory.zeros(0, CompoundDoubleDataset.class, null);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		exp = new CompoundDoubleDataset(1);
 		act = DatasetFactory.compoundZeros(1, CompoundDoubleDataset.class, null);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		exp = new CompoundDoubleDataset(2);
 		act = DatasetFactory.zeros(2, CompoundDoubleDataset.class, null);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		// zero-ranked (unit size)
 		exp = new CompoundDoubleDataset(1, new int[0]);
 		act = DatasetFactory.compoundZeros(1, CompoundDoubleDataset.class);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		exp = new CompoundDoubleDataset(2, new int[0]);
 		act = DatasetFactory.zeros(2, CompoundDoubleDataset.class);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		// one dimensional
 		exp = new CompoundDoubleDataset(1, new int[] {3});
 		act = DatasetFactory.compoundZeros(1, CompoundDoubleDataset.class, 3);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		exp = new CompoundDoubleDataset(2, new int[] {3});
 		act = DatasetFactory.zeros(2, CompoundDoubleDataset.class, 3);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		// three dimensional
 		exp = new CompoundDoubleDataset(1, new int[] {3, 4, 5});
 		act = DatasetFactory.compoundZeros(1, CompoundDoubleDataset.class, 3, 4, 5);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		exp = new CompoundDoubleDataset(2, new int[] {3, 4, 5});
 		act = DatasetFactory.zeros(2, CompoundDoubleDataset.class, 3, 4, 5);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 	}
 
 	@Test
@@ -133,47 +133,47 @@ public class DatasetFactoryTest {
 		exp = new DoubleDataset();
 
 		act = DatasetFactory.createFromObject(DoubleDataset.class, (Object) null);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		act = DatasetFactory.createFromObject(DoubleDataset.class, null, null);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		act = DatasetFactory.createFromObject(DoubleDataset.class, new double[0], null);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		act = DatasetFactory.createFromObject(DoubleDataset.class, new double[0]);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		act = DatasetFactory.createFromObject(DoubleDataset.class, null, 0);
-		assertEquals(exp.reshape(0), act);
+		TestUtils.assertDatasetEquals(exp.reshape(0), act);
 
 		act = DatasetFactory.createFromObject(DoubleDataset.class, new double[0], 0);
-		assertEquals(exp.reshape(0), act);
+		TestUtils.assertDatasetEquals(exp.reshape(0), act);
 
 		act = DatasetFactory.createFromObject(DoubleDataset.class, new double[0], 0, 0, 0);
-		assertEquals(exp.reshape(0, 0, 0), act);
+		TestUtils.assertDatasetEquals(exp.reshape(0, 0, 0), act);
 
 		act = DatasetFactory.createFromObject(DoubleDataset.class, new double[0], 0, 1, 0);
-		assertEquals(exp.reshape(0, 1, 0), act);
+		TestUtils.assertDatasetEquals(exp.reshape(0, 1, 0), act);
 
 		// zero-ranked (unit size)
 		exp = new DoubleDataset(new double[] {3});
 		exp.setShape();
 		act = DatasetFactory.createFromObject(DoubleDataset.class, (Object) 3);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		// one dimensional
 		exp = new DoubleDataset(new double[] { 3, 4, 5 });
 		act = DatasetFactory.createFromObject(DoubleDataset.class, new double[] { 3, 4, 5 });
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		// two dimensional
 		exp = new DoubleDataset(new double[] {3, 4, 5, 6, 7, 8}, 2, 3);
 		act = DatasetFactory.createFromObject(DoubleDataset.class, new double[] {3, 4, 5, 6, 7, 8}, 2, 3);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		act = DatasetFactory.createFromObject(DoubleDataset.class, new double[][] {{3, 4, 5}, {6, 7, 8}});
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 	}
 
 	@Test
@@ -183,29 +183,29 @@ public class DatasetFactoryTest {
 		// zero-sized
 		exp = new IntegerDataset();
 		act = DatasetFactory.createFromObject(IntegerDataset.class, null, null);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		act = DatasetFactory.createFromObject(IntegerDataset.class, new int[0], null);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		// zero-ranked (unit size)
 		exp = new IntegerDataset(new int[] {3}, null);
 		exp.setShape();
 		act = DatasetFactory.createFromObject(IntegerDataset.class, (Object) 3);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		// one dimensional
 		exp = new IntegerDataset(new int[] { 3, 4, 5 }, null);
 		act = DatasetFactory.createFromObject(IntegerDataset.class, new int[] { 3, 4, 5 }, null);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		// two dimensional
 		exp = new IntegerDataset(new int[] {3, 4, 5, 6, 7, 8}, 2, 3);
 		act = DatasetFactory.createFromObject(IntegerDataset.class, new int[] {3, 4, 5, 6, 7, 8}, 2, 3);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		act = DatasetFactory.createFromObject(IntegerDataset.class, new int[][] {{3, 4, 5}, {6, 7, 8}});
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 	}
 
 	@Test
@@ -215,23 +215,23 @@ public class DatasetFactoryTest {
 		// zero-sized
 		exp = new DoubleDataset();
 		act = DatasetFactory.createFromObject(1, DoubleDataset.class, null, null);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		// zero-ranked (unit size)
 		exp = new DoubleDataset(new double[] {3});
 		exp.setShape();
 		act = DatasetFactory.createFromObject(1, DoubleDataset.class, (Object) 3);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		// one dimensional
 		exp = new DoubleDataset(new double[] { 3, 4, 5 });
 		act = DatasetFactory.createFromObject(1, DoubleDataset.class, new double[] { 3, 4, 5 });
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		// two dimensional
 		exp = new DoubleDataset(new double[] {3, 4, 5, 6, 7, 8}, 2, 3);
 		act = DatasetFactory.createFromObject(1, DoubleDataset.class, new double[] {3, 4, 5, 6, 7, 8}, 2, 3);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 	}
 
 	@Test
@@ -241,42 +241,42 @@ public class DatasetFactoryTest {
 		// zero-sized
 		exp = new CompoundDoubleDataset();
 		act = DatasetFactory.createFromObject(0, CompoundDoubleDataset.class, null, null);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		exp = new CompoundDoubleDataset(1);
 		act = DatasetFactory.createFromObject(1, CompoundDoubleDataset.class, null, null);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		exp = new CompoundDoubleDataset(2);
 		act = DatasetFactory.createFromObject(2, CompoundDoubleDataset.class, null, null);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		// zero-ranked (unit size)
 		exp = new CompoundDoubleDataset(1, new double[] {3}, new int[0]);
 		act = DatasetFactory.createFromObject(1, CompoundDoubleDataset.class, 3.);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		exp = new CompoundDoubleDataset(2, new double[] {3, 4}, new int[0]);
 		act = DatasetFactory.createFromObject(2, CompoundDoubleDataset.class, new double[] {3, 4});
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		// one dimensional
 		exp = new CompoundDoubleDataset(1, new double[] {3, 4, 5, 6});
 		act = DatasetFactory.createFromObject(1, CompoundDoubleDataset.class, new double[] {3, 4, 5, 6});
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		exp = new CompoundDoubleDataset(2, new double[] {3, 4, 5, 6});
 		act = DatasetFactory.createFromObject(2, CompoundDoubleDataset.class, new double[] {3, 4, 5, 6});
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		// two dimensional
 		exp = new CompoundDoubleDataset(1, new double[] {3, 5, 7}, new int[] {3, 1});
 		act = DatasetFactory.createFromObject(1, CompoundDoubleDataset.class, new double[] {3, 5, 7}, 3, 1);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		exp = new CompoundDoubleDataset(2, new double[] {3, 4, 5, 6, 7, 8}, new int[] {3, 1});
 		act = DatasetFactory.createFromObject(2, CompoundDoubleDataset.class, new double[] {3, 4, 5, 6, 7, 8}, 3, 1);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 	}
 
 	@Test
@@ -286,27 +286,27 @@ public class DatasetFactoryTest {
 		// zero-sized
 		exp = new RGBDataset();
 		act = DatasetFactory.createFromObject(0, RGBDataset.class, null, null);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		// zero-ranked (unit size)
 		exp = new RGBDataset(new short[] {3, 4, 5}, new int[0]);
 		act = DatasetFactory.createFromObject(2, RGBDataset.class, new short[] {3, 4, 5});
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		// one dimensional
 		exp = new RGBDataset(new short[] {3, 4, 5, 6, 7, 8});
 		act = DatasetFactory.createFromObject(2, RGBDataset.class, new short[] {3, 4, 5, 6, 7, 8});
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		// two dimensional
 		exp = new RGBDataset(new short[] {3, 4, 5, 6, 7, 8, 9, 0, 1}, new int[] {3, 1});
 		act = DatasetFactory.createFromObject(2, RGBDataset.class, new short[] {3, 4, 5, 6, 7, 8, 9, 0, 1}, 3, 1);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		// one dimensional
 		exp = new RGBDataset(new short[] {3, 4, 5, 6, 7, 8});
 		act = DatasetFactory.createFromObject(RGBDataset.class, new short[] {3, 4, 5, 6, 7, 8});
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 	}
 
 	@Test
@@ -317,17 +317,17 @@ public class DatasetFactoryTest {
 		assertArrayEquals(new int[] {3, 5, 2}, act.getShapeRef());
 		Dataset b = a.reshape(1, 5, 2);
 		Dataset exp = DatasetUtils.concatenate(new IDataset[] {b, b, b}, 0);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		List<IDataset> list = new ArrayList<>();
 		list.add(a);
 		list.add(a);
 		list.add(a);
 		act = DatasetFactory.createFromObject(list);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 
 		act = DatasetFactory.createFromList(list);
-		assertEquals(exp, act);
+		TestUtils.assertDatasetEquals(exp, act);
 	}
 
 	@Test

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/DatasetFactoryTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/DatasetFactoryTest.java
@@ -277,6 +277,20 @@ public class DatasetFactoryTest {
 		exp = new CompoundDoubleDataset(2, new double[] {3, 4, 5, 6, 7, 8}, new int[] {3, 1});
 		act = DatasetFactory.createFromObject(2, CompoundDoubleDataset.class, new double[] {3, 4, 5, 6, 7, 8}, 3, 1);
 		TestUtils.assertDatasetEquals(exp, act);
+
+		act = DatasetFactory.createCompoundDataset(CompoundDoubleDataset.class, new double[] {3, 5, 7} , new double[] {4, 6, 8});
+		act.setShape(3, 1);
+		TestUtils.assertDatasetEquals(exp, act);
+	}
+
+	@Test
+	public void testCreatorComplex() {
+		ComplexDoubleDataset act, exp;
+
+		exp = new ComplexDoubleDataset(new double[] {3, 5, 7}, new double[] {4, 6, 8}, new int[] {3, 1});
+		act = DatasetFactory.createComplexDataset(ComplexDoubleDataset.class, new double[] {3, 5, 7} , new double[] {4, 6, 8});
+		act.setShape(3, 1);
+		TestUtils.assertDatasetEquals(exp, act);
 	}
 
 	@Test

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/DoubleDatasetTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/DoubleDatasetTest.java
@@ -232,7 +232,7 @@ public class DoubleDatasetTest {
 	@Test
 	public void testStats() {
 		Dataset a = DatasetFactory.createRange(12);
-		assertEquals(11., a.max().doubleValue(), 1e-6);
+		assertEquals(Double.valueOf(11), a.max());
 		assertEquals(0., a.min().doubleValue(), 1e-6);
 		assertEquals(5.5, ((Number) a.mean()).doubleValue(), 1e-6);
 		assertEquals(3.6055512754639891, a.stdDeviation(), 1e-6);

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/DoubleDatasetTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/DoubleDatasetTest.java
@@ -555,11 +555,27 @@ public class DoubleDatasetTest {
 		c = a.clone();
 		TestUtils.assertDatasetEquals(Maths.power(a, z).cast(DoubleDataset.class), c.ipower(z));
 
-
 		// floor
 		a = Maths.multiply(a, 1.5);
 
 		c = a.clone();
 		TestUtils.assertDatasetEquals(Maths.floor(a), c.ifloor());
+	}
+
+	static class DoubleDataset2 extends DoubleDataset {
+		private static final long serialVersionUID = 1L;
+
+		public DoubleDataset2(final DoubleDataset dataset) {
+			super(dataset);
+		}
+	}
+
+	@Test
+	public void testSubclassing() {
+		double[] da = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+		DoubleDataset a = new DoubleDataset(da);
+
+		DoubleDataset2 b = new DoubleDataset2(a);
+		TestUtils.assertDatasetEquals(a, b);
 	}
 }

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/DoubleDatasetTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/DoubleDatasetTest.java
@@ -12,6 +12,7 @@ package org.eclipse.january.dataset;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import org.apache.commons.math3.complex.Complex;
@@ -237,6 +238,27 @@ public class DoubleDatasetTest {
 		assertEquals(5.5, ((Number) a.mean()).doubleValue(), 1e-6);
 		assertEquals(3.6055512754639891, a.stdDeviation(), 1e-6);
 		assertEquals(13., a.variance(), 1e-6);
+
+		// invalid slice view check
+		Dataset v = a.getSliceView(new Slice(14, 24));
+		try {
+			v.max();
+			fail("Should have thrown exception");
+		} catch (UnsupportedOperationException e) {
+			// do nothing
+		} catch (Exception e) {
+			fail("Unexpected exception");
+		}
+		try {
+			v.minPos();
+			fail("Should have thrown exception");
+		} catch (UnsupportedOperationException e) {
+			// do nothing
+		} catch (Exception e) {
+			fail("Unexpected exception");
+		}
+		assertEquals(0., ((Number) v.sum()).doubleValue(), 1e-6);
+		assertTrue(Double.isNaN(((Number) v.mean()).doubleValue()));
 
 		a.setShape(3, 1, 4);
 		Dataset b = a.sum(0);

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/FloatDatasetTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/FloatDatasetTest.java
@@ -47,7 +47,7 @@ public class FloatDatasetTest {
 	@Test
 	public void testStats() {
 		Dataset a = DatasetFactory.createRange(FloatDataset.class, 12);
-		assertEquals(11., a.max().doubleValue(), 1e-6);
+		assertEquals(Float.valueOf(11), a.max());
 		assertEquals(0., a.min().doubleValue(), 1e-6);
 		assertEquals(5.5, ((Number) a.mean()).doubleValue(), 1e-6);
 		assertEquals(3.6055512754639891, a.stdDeviation(), 1e-6);

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/IndexIteratorTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/IndexIteratorTest.java
@@ -47,6 +47,20 @@ public class IndexIteratorTest {
 		assertFalse(it.hasNext());
 	}
 
+	@Test
+	public void testNullShapeIteration() {
+		Dataset ta = DatasetFactory.zeros((int[]) null);
+		IndexIterator it = ta.getIterator();
+
+		assertFalse(it.hasNext());
+
+		it = ta.getIterator(true);
+		assertFalse(it.hasNext());
+
+		it = new ContiguousIteratorWithPosition(null, 0);
+		assertFalse(it.hasNext());
+	}
+
 	private void testIterationsND(int size, Class<? extends Dataset> clazz) {
 		Dataset ta;
 

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/IntegerDatasetTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/IntegerDatasetTest.java
@@ -50,7 +50,7 @@ public class IntegerDatasetTest {
 	@Test
 	public void testStats() {
 		Dataset a = DatasetFactory.createRange(IntegerDataset.class, 12);
-		assertEquals(11., a.max().doubleValue(), 1e-6);
+		assertEquals(Integer.valueOf(11), a.max());
 		assertEquals(0., a.min().doubleValue(), 1e-6);
 		assertEquals(5.5, ((Number) a.mean()).doubleValue(), 1e-6);
 		assertEquals(3.6055512754639891, a.stdDeviation(), 1e-6);

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/IntegersIteratorTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/IntegersIteratorTest.java
@@ -309,8 +309,12 @@ public class IntegersIteratorTest {
 
 	@Test
 	public void testZeroSizedIteration() {
-		IntegersIterator it = new IntegersIterator(new int[] {4, 0, 4});
+		IntegersIterator it;
 
+		it = new IntegersIterator(null);
+		assertFalse(it.hasNext());
+
+		it = new IntegersIterator(new int[] {4, 0, 4});
 		assertFalse(it.hasNext());
 
 		it = new IntegersIterator(new int[] {4, 4, 4}, new Slice(2, 2));

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/LazyDatasetTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/LazyDatasetTest.java
@@ -9,6 +9,8 @@
 
 package org.eclipse.january.dataset;
 
+import static org.junit.Assert.fail;
+
 import java.util.Arrays;
 import java.util.Comparator;
 
@@ -125,6 +127,31 @@ public class LazyDatasetTest {
 		slice = new Slice[]{null, null, null, new Slice(null, null, -1)};
 		nd = ld.getSlice(slice);
 		Assert.assertEquals("Full negative slice", d.getSlice(slice), nd);
+
+		// test input SliceND checking
+		try {
+			ld.getSlice(new SliceND(null));
+			fail();
+		} catch (IllegalArgumentException e) {
+			System.out.println("As expected: " + e);
+		}
+
+		try {
+			ld.getSlice(new SliceND(new int[0]));
+			fail();
+		} catch (IllegalArgumentException e) {
+			System.out.println("As expected: " + e);
+		}
+
+		try {
+			ld.getSlice(new SliceND(new int[2]));
+			fail();
+		} catch (IllegalArgumentException e) {
+			System.out.println("As expected: " + e);
+		}
+
+		nd = ld.getSlice(new SliceND(ld.getShape()));
+		Assert.assertEquals("Full slice", d.getSlice(), nd);
 	}
 
 	@Test
@@ -161,6 +188,31 @@ public class LazyDatasetTest {
 		slice = new Slice[]{null, null, null, new Slice(null, null, -1)};
 		l = ld.getSliceView(slice);
 		Assert.assertEquals("Full negative slice", d.getSlice(slice), l.getSlice());
+
+		// test input SliceND checking
+		try {
+			ld.getSliceView(new SliceND(null));
+			fail();
+		} catch (IllegalArgumentException e) {
+			System.out.println("As expected: " + e);
+		}
+
+		try {
+			ld.getSliceView(new SliceND(new int[0]));
+			fail();
+		} catch (IllegalArgumentException e) {
+			System.out.println("As expected: " + e);
+		}
+
+		try {
+			ld.getSliceView(new SliceND(new int[2]));
+			fail();
+		} catch (IllegalArgumentException e) {
+			System.out.println("As expected: " + e);
+		}
+
+		l = ld.getSliceView(new SliceND(ld.getShape()));
+		Assert.assertEquals("Full slice", d, l.getSlice());
 	}
 
 	@Test

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/LazyDatasetTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/LazyDatasetTest.java
@@ -45,7 +45,7 @@ public class LazyDatasetTest {
 
 	@Test
 	public void testSetShape() {
-		LazyDataset ld = new LazyDataset("", Dataset.INT, new int[] {1, 2, 3, 4}, null);
+		LazyDataset ld = new LazyDataset(null, "", IntegerDataset.class, 1, 2, 3, 4);
 
 		setShape("check on same rank", true, ld, 1, 2, 3, 4);
 		setShape("check on same rank", false, ld, 1, 2, 3, 5);
@@ -62,10 +62,10 @@ public class LazyDatasetTest {
 		setShape("check on lesser rank", false, ld, 3, 4);
 		setShape("check on lesser rank", false, ld, 2, 3);
 
-		ld = new LazyDataset("", Dataset.INT, new int[] {2, 3, 4, 1}, null);
+		ld = new LazyDataset(null, "", IntegerDataset.class, 2, 3, 4, 1);
 		setShape("check on lesser rank", true, ld, 2, 3, 4);
 
-		ld = new LazyDataset("", Dataset.INT, new int[] {1, 2, 3, 4, 1}, null);
+		ld = new LazyDataset(null, "", IntegerDataset.class, 1, 2, 3, 4, 1);
 		setShape("check on lesser rank", true, ld, 2, 3, 4);
 	}
 

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/LazyDynamicDatasetTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/LazyDynamicDatasetTest.java
@@ -12,11 +12,6 @@ package org.eclipse.january.dataset;
 import java.util.Arrays;
 
 import org.eclipse.january.asserts.TestUtils;
-import org.eclipse.january.dataset.DataEvent;
-import org.eclipse.january.dataset.Dataset;
-import org.eclipse.january.dataset.IDataListener;
-import org.eclipse.january.dataset.IDynamicDataset;
-import org.eclipse.january.dataset.LazyDynamicDataset;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -33,7 +28,7 @@ public class LazyDynamicDatasetTest {
 	}
 
 	IDynamicDataset createDynamic() {
-		IDynamicDataset lazy = new LazyDynamicDataset("test", Dataset.INT32, 1, new int[] {0,4}, new int[] {IDynamicDataset.UNLIMITED, 4}, null);
+		IDynamicDataset lazy = new LazyDynamicDataset(null, "test", 1, IntegerDataset.class, new int[] {0,4}, new int[] {IDynamicDataset.UNLIMITED, 4});
 		return lazy;
 	}
 

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/LazyDynamicLoaderTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/LazyDynamicLoaderTest.java
@@ -133,15 +133,16 @@ public class LazyDynamicLoaderTest {
 		IDataset data;
 		SliceNDIterator iterator;
 		boolean hasNext = true;
+		private int[] dShape;
 		
 		LazyDynamicTestLoader(IDataset data, int detectorRank) {
 			this.data = data;
-			this.currentShape = determineInitialShape(data.getShape(), detectorRank);
+			this.dShape = data.getShape();
+			this.currentShape = determineInitialShape(dShape, detectorRank);
 			int[] axes = new int[detectorRank];
 			for (int i = 0; i < detectorRank; i++) axes[i] = data.getRank()-1-i;
-			iterator = new SliceNDIterator(new SliceND(data.getShape()), axes);
+			iterator = new SliceNDIterator(new SliceND(dShape), axes);
 			iterator.hasNext();
-			
 		}
 		
 		@Override
@@ -160,7 +161,9 @@ public class LazyDynamicLoaderTest {
 
 		@Override
 		public IDataset getDataset(IMonitor mon, SliceND slice) throws IOException {
-			return data.getSlice(slice);
+			SliceND nSlice = slice.clone();
+			nSlice.updateSourceShape(dShape);
+			return data.getSlice(nSlice);
 		}
 		
 	}

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/LazyDynamicLoaderTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/LazyDynamicLoaderTest.java
@@ -110,8 +110,7 @@ public class LazyDynamicLoaderTest {
 	private LazyDynamicDataset getDataset(IDataset data, int detectorRank, String name) {
 		
 		int[] shape = determineInitialShape(data.getShape(), detectorRank);
-		return new LazyDynamicDataset(name, Dataset.FLOAT64, 1, shape, data.getShape(), new LazyDynamicTestLoader(data, detectorRank));
-		
+		return new LazyDynamicDataset(new LazyDynamicTestLoader(data, detectorRank), name, 1, DoubleDataset.class, shape, data.getShape());
 	}
 	
 	private static int[] determineInitialShape(int[] maxShape, int detectorRank) {

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/LinearAlgebraTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/LinearAlgebraTest.java
@@ -45,7 +45,7 @@ public class LinearAlgebraTest {
 		System.out.printf("Time taken %dus\n", start/1000);
 
 		assertArrayEquals("Shape", new int[] {5, 2}, c.getShapeRef());
-		assertEquals("Type", Dataset.FLOAT32, c.getDType());
+		assertTrue("Interface", c instanceof FloatDataset);
 
 		Dataset d = DatasetFactory.createFromObject(new double[] { 4400., 4730.,
 			4532.,  4874., 4664., 5018., 4796.,  5162., 4928.,  5306. }, 5, 2);

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/LongDatasetTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/LongDatasetTest.java
@@ -71,7 +71,7 @@ public class LongDatasetTest {
 	@Test
 	public void testStats() {
 		Dataset a = DatasetFactory.createRange(LongDataset.class, 12);
-		assertEquals(11., a.max().doubleValue(), 1e-6);
+		assertEquals(Long.valueOf(11), a.max());
 		assertEquals(0., a.min().doubleValue(), 1e-6);
 		assertEquals(5.5, ((Number) a.mean()).doubleValue(), 1e-6);
 		assertEquals(3.6055512754639891, a.stdDeviation(), 1e-6);

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/MathsTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/MathsTest.java
@@ -2452,4 +2452,32 @@ public class MathsTest {
 		TestUtils.assertDatasetEquals(Maths.clip(c, 0.2, 15), Maths.lowerClip(c, 0.2));
 		TestUtils.assertDatasetEquals(Maths.clip(c, 0.21, 15), Maths.lowerClip(c, 0.21));
 	}
+
+	@Test
+	public void testDerivativeOnSliceViews() {
+		Dataset x = Random.rand(60).sort(null);
+		Dataset y = Random.rand(60);
+
+		testDerivativeOnSliceViews(x, y, null);
+		testDerivativeOnSliceViews(x, y, new Slice(15));
+		testDerivativeOnSliceViews(x, y, new Slice(2, null));
+		testDerivativeOnSliceViews(x, y, new Slice(2, null, 3));
+		testDerivativeOnSliceViews(x, y, new Slice(2, 15));
+		testDerivativeOnSliceViews(x, y, new Slice(15, null, -2));
+
+		x.setShape(20, 3);
+		y.setShape(x.getShapeRef());
+		x = DatasetUtils.createCompoundDatasetFromLastAxis(x, true);
+		y = DatasetUtils.createCompoundDatasetFromLastAxis(y, true);
+		testDerivativeOnSliceViews(x, y, null);
+		testDerivativeOnSliceViews(x, y, new Slice(15));
+		testDerivativeOnSliceViews(x, y, new Slice(2, null));
+		testDerivativeOnSliceViews(x, y, new Slice(2, null, 3));
+		testDerivativeOnSliceViews(x, y, new Slice(2, 15));
+		testDerivativeOnSliceViews(x, y, new Slice(15, null, -2));
+	}
+
+	private void testDerivativeOnSliceViews(Dataset x, Dataset y, Slice s) {
+		TestUtils.assertDatasetEquals(Maths.derivative(x.getSlice(s), y.getSlice(s), 2), Maths.derivative(x.getSlice(s), y.getSliceView(s), 2));
+	}
 }

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/PositionIteratorTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/PositionIteratorTest.java
@@ -47,6 +47,13 @@ public class PositionIteratorTest {
 	}
 
 	@Test
+	public void testNullShapeIteration() {
+		PositionIterator it = new PositionIterator(null);
+
+		assertFalse(it.hasNext());
+	}
+
+	@Test
 	public void testZeroSizedIteration() {
 		PositionIterator it = new PositionIterator(new int[] {4, 0, 4});
 

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/RGBDatasetTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/RGBDatasetTest.java
@@ -128,5 +128,9 @@ public class RGBDatasetTest {
 		h.iadd(360);
 		a = RGBDataset.createFromHSL(h, s, l);
 		TestUtils.assertDatasetEquals(rgb, a, 1, 1);
+
+		FloatDataset bf = rgb.createBlueDataset(FloatDataset.class);
+		s = DatasetFactory.createFromObject(FloatDataset.class, new short[] {0, 0, 0, 255, 255, 191});
+		TestUtils.assertDatasetEquals(s, bf, 1, 1);
 	}
 }

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/RGBDatasetTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/RGBDatasetTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
  * Basic tests of RGB dataset
  */
 public class RGBDatasetTest {
+
 	@Test
 	public void testConstructors() {
 		assertEquals(0, new RGBDataset().getSize());
@@ -75,6 +76,23 @@ public class RGBDatasetTest {
 			assertEquals(i, c.getRed(i));
 			assertEquals(0, c.getGreen(i));
 			assertEquals(0, c.getBlue(i));
+		}
+	}
+
+	@Test
+	public void testConstructorsWithSliceViews() {
+		int n = 10;
+		Dataset a = DatasetFactory.createRange(IntegerDataset.class, 3*n).reshape(3, n);
+
+		Dataset r = a.getSliceView(new Slice(0, 1)).squeeze();
+		Dataset g = a.getSliceView(new Slice(1, 2)).squeeze();
+		Dataset b = a.getSliceView(new Slice(2, 3)).squeeze();
+
+		RGBDataset c = new RGBDataset(r, g, b);
+		for (int i = 0; i < n; i++) {
+			assertEquals(r.getInt(i), c.getRed(i));
+			assertEquals(g.getInt(i), c.getGreen(i));
+			assertEquals(b.getInt(i), c.getBlue(i));
 		}
 	}
 

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/ShortDatasetTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/ShortDatasetTest.java
@@ -47,7 +47,7 @@ public class ShortDatasetTest {
 	@Test
 	public void testStats() {
 		Dataset a = DatasetFactory.createRange(ShortDataset.class, 12);
-		assertEquals(11., a.max().doubleValue(), 1e-6);
+		assertEquals(Short.valueOf((short) 11), a.max());
 		assertEquals(0., a.min().doubleValue(), 1e-6);
 		assertEquals(5.5, ((Number) a.mean()).doubleValue(), 1e-6);
 		assertEquals(3.6055512754639891, a.stdDeviation(), 1e-6);

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/SliceIteratorTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/SliceIteratorTest.java
@@ -33,6 +33,13 @@ public class SliceIteratorTest {
 	}
 
 	@Test
+	public void testNullShapeIteration() {
+		IndexIterator it = new SliceIterator(null, 0, (int[]) null);
+
+		assertFalse(it.hasNext());
+	}
+
+	@Test
 	public void testZeroSizedIteration() {
 		Dataset ta = DatasetFactory.createRange(24);
 		IndexIterator it = ta.getSliceIterator(null, new int[] {0}, null);

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/SliceNDIteratorTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/SliceNDIteratorTest.java
@@ -11,6 +11,7 @@ package org.eclipse.january.dataset;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 import java.util.Arrays;
 
@@ -47,9 +48,14 @@ public class SliceNDIteratorTest {
 		assertEquals(4*5, size);
 	}
 
-	/**
-	 * 
-	 */
+	@Test
+	public void testNullShapeIterations() {
+		SliceND sa = new SliceND(null);
+
+		SliceNDIterator it = new SliceNDIterator(sa);
+		assertFalse(it.hasNext());
+	}
+
 	@Test
 	public void testIterations() {
 		SliceND sa = new SliceND(new int[] {4, 5, 6, 7}, new Slice(1, 5, 2), null, null, null);

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/SliceNDIteratorTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/SliceNDIteratorTest.java
@@ -12,6 +12,7 @@ package org.eclipse.january.dataset;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 
 import java.util.Arrays;
 
@@ -128,5 +129,51 @@ public class SliceNDIteratorTest {
 	private static void myAssertEquals(SliceND a, SliceND b) {
 		assertArrayEquals(a.getSourceShape(), b.getSourceShape());
 		assertArrayEquals(a.getShape(), b.getShape());
+	}
+
+	@Test
+	public void testIterationsAll() {
+		SliceND sa = new SliceND(new int[] {7});
+
+		SliceNDIterator it = new SliceNDIterator(sa);
+
+		assertArrayEquals(new int[]{7}, it.getShape());
+		assertNull(it.getOmittedSlice());
+
+		int size = 0;
+		while (it.hasNext()) {
+			TestUtils.verbosePrintln(size + ": " + Arrays.toString(it.getPos()) + " or " + Arrays.toString(it.getUsedPos()));
+			TestUtils.verbosePrintln("use: " + it.getUsedSlice() + ", cur: " + it.getCurrentSlice() + ", out: " + it.getOutputSlice());
+			if (size == 3) {
+				assertArrayEquals(new int[]{3}, it.getPos());
+				assertArrayEquals(new int[]{3}, it.getUsedPos());
+				myAssertEquals(new SliceND(new int[] {7}, new Slice(3, 4)), it.getUsedSlice());
+				myAssertEquals(new SliceND(new int[] {7}, new Slice(3, 4)), it.getOutputSlice());
+			}
+			size++;
+		}
+	}
+
+	@Test
+	public void testIterationsSlicedSameRank() {
+		SliceND sa = new SliceND(new int[] {12}, new Slice(2, 9));
+
+		SliceNDIterator it = new SliceNDIterator(sa);
+
+		assertArrayEquals(new int[]{7}, it.getShape());
+		assertNull(it.getOmittedSlice());
+
+		int size = 0;
+		while (it.hasNext()) {
+			TestUtils.verbosePrintln(size + ": " + Arrays.toString(it.getPos()) + " or " + Arrays.toString(it.getUsedPos()));
+			TestUtils.verbosePrintln("use: " + it.getUsedSlice() + ", cur: " + it.getCurrentSlice() + ", out: " + it.getOutputSlice());
+			if (size == 3) {
+				assertArrayEquals(new int[]{5}, it.getPos());
+				assertArrayEquals(new int[]{5}, it.getUsedPos());
+				myAssertEquals(new SliceND(new int[] {12}, new Slice(5, 6)), it.getUsedSlice());
+				myAssertEquals(new SliceND(new int[] {7}, new Slice(3, 4)), it.getOutputSlice());
+			}
+			size++;
+		}
 	}
 }

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/SliceNDTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/SliceNDTest.java
@@ -11,7 +11,6 @@ package org.eclipse.january.dataset;
 
 import static org.junit.Assert.fail;
 
-import org.eclipse.january.dataset.SliceND;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -23,6 +22,14 @@ public class SliceNDTest {
 		int[] lstart;
 		int[] lstop;
 		SliceND slice;
+
+		// null dataset
+		slice = new SliceND(null);
+		Assert.assertTrue(slice.isAll());
+
+		// zero-rank dataset
+		slice = new SliceND(new int[0]);
+		Assert.assertTrue(slice.isAll());
 
 		step = new int[] {};
 		lstart = new int[] {};
@@ -1017,5 +1024,76 @@ public class SliceNDTest {
 		Assert.assertEquals(511, slice.getStart()[0]);
 		Assert.assertEquals(512, slice.getShape()[0]);
 		Assert.assertEquals(-1, slice.getStop()[0]);
+	}
+
+	@Test
+	public void testSliceWithinShape() {
+		Assert.assertTrue(SliceND.isSliceWithinShape(0, 0, 0, 1));
+
+		Assert.assertTrue(SliceND.isSliceWithinShape(5, 0, 5, 1));
+		Assert.assertTrue(SliceND.isSliceWithinShape(5, 1, 1, 1));
+		Assert.assertTrue(SliceND.isSliceWithinShape(5, 1, 5, 1));
+		Assert.assertTrue(SliceND.isSliceWithinShape(5, 4, 4, 1));
+		Assert.assertFalse(SliceND.isSliceWithinShape(5, 5, 5, 1));
+		Assert.assertFalse(SliceND.isSliceWithinShape(5, 2, 1, 1));
+
+		Assert.assertTrue(SliceND.isSliceWithinShape(5, 4, -1, -1));
+		Assert.assertTrue(SliceND.isSliceWithinShape(5, 1, 1, -1));
+		Assert.assertTrue(SliceND.isSliceWithinShape(5, 4, 0, -1));
+		Assert.assertTrue(SliceND.isSliceWithinShape(5, 4, 4, -1));
+		Assert.assertFalse(SliceND.isSliceWithinShape(5, 5, 5, -1));
+		Assert.assertFalse(SliceND.isSliceWithinShape(5, -1, -1, -1));
+		Assert.assertFalse(SliceND.isSliceWithinShape(5, 1, 2, -1));
+	}
+
+	@Test
+	public void testUpdateSourceShape() {
+		SliceND slice = new SliceND(new int[] {8, 4}, new int[] {6 , 1}, new int[] {2, 4}, new int[] {-3, 1});
+
+		slice.updateSourceShape(13, 4);
+
+		slice.updateSourceShape(8, 6);
+
+		try {
+			slice.updateSourceShape(8, 3);
+			fail();
+		} catch (IllegalArgumentException e) {
+			System.out.println("As expected: " + e);
+		}
+
+		try {
+			slice.updateSourceShape(3, 4);
+			fail();
+		} catch (IllegalArgumentException e) {
+			System.out.println("As expected: " + e);
+		}
+
+		try {
+			slice.updateSourceShape(1, 4);
+			fail();
+		} catch (IllegalArgumentException e) {
+			System.out.println("As expected: " + e);
+		}
+
+		try {
+			slice.updateSourceShape(3);
+			fail();
+		} catch (IllegalArgumentException e) {
+			System.out.println("As expected: " + e);
+		}
+
+		try {
+			slice.updateSourceShape();
+			fail();
+		} catch (IllegalArgumentException e) {
+			System.out.println("As expected: " + e);
+		}
+
+		try {
+			slice.updateSourceShape(null);
+			fail();
+		} catch (IllegalArgumentException e) {
+			System.out.println("As expected: " + e);
+		}
 	}
 }

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/StrideIteratorTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/StrideIteratorTest.java
@@ -38,6 +38,13 @@ public class StrideIteratorTest {
 	}
 
 	@Test
+	public void testNullShapeIteration() {
+		StrideIterator it = new StrideIterator(null);
+
+		assertFalse(it.hasNext());
+	}
+
+	@Test
 	public void testZeroSizedIteration() {
 		Dataset ta = DatasetFactory.zeros(new int[] {4,4,4});
 

--- a/org.eclipse.january.test/src/org/eclipse/january/metadata/internal/AxesMetadataTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/metadata/internal/AxesMetadataTest.java
@@ -25,6 +25,7 @@ import org.eclipse.january.dataset.DatasetUtils;
 import org.eclipse.january.dataset.DoubleDataset;
 import org.eclipse.january.dataset.IDataset;
 import org.eclipse.january.dataset.ILazyDataset;
+import org.eclipse.january.dataset.IntegerDataset;
 import org.eclipse.january.dataset.Random;
 import org.eclipse.january.dataset.Slice;
 import org.eclipse.january.metadata.AxesMetadata;
@@ -49,7 +50,7 @@ public class AxesMetadataTest {
 		}
 
 
-		ILazyDataset dataset = Random.lazyRand(Dataset.INT32, "Main", shape);
+		ILazyDataset dataset = Random.lazyRand("Main", IntegerDataset.class, shape);
 		dataset.addMetadata(amd);
 
 		try {
@@ -131,7 +132,7 @@ public class AxesMetadataTest {
 			DoubleDataset array = Random.randn(nShape);
 			amd.setAxis(i, array);
 		}
-		ILazyDataset dataset = Random.lazyRand(Dataset.INT32, "Main", shape);
+		ILazyDataset dataset = Random.lazyRand("Main", IntegerDataset.class, shape);
 		dataset.addMetadata(amd);
 		dataset.setShape(reshape);
 	}
@@ -142,8 +143,7 @@ public class AxesMetadataTest {
 
 		int r = shape.length;
 
-		ILazyDataset dataset = Random.lazyRand(Dataset.INT32, "Main", shape);
-
+		ILazyDataset dataset = Random.lazyRand("Main", IntegerDataset.class, shape);
 		AxesMetadata amd = MetadataFactory.createMetadata(AxesMetadata.class, r);
 		dataset.addMetadata(amd);
 
@@ -168,20 +168,20 @@ public class AxesMetadataTest {
 
 		int r = shape.length;
 
-		ILazyDataset axis = Random.lazyRand(Dataset.INT32, "axis", 2);
+		ILazyDataset axis = Random.lazyRand("axis", IntegerDataset.class, 2);
 		AxesMetadata amd = MetadataFactory.createMetadata(AxesMetadata.class, 1);
-		amd.setAxis(0, Random.lazyRand(Dataset.INT32, "axis2", 2));
+		amd.setAxis(0, Random.lazyRand("axis2", IntegerDataset.class, 2));
 		axis.addMetadata(amd);
 
 		amd = MetadataFactory.createMetadata(AxesMetadata.class, r);
 		amd.setAxis(1, axis);
-		ILazyDataset dataset = Random.lazyRand(Dataset.INT32, "Main", shape);
+		ILazyDataset dataset = Random.lazyRand("Main", IntegerDataset.class, shape);
 		dataset.addMetadata(amd);
 
 		dataset.setShape(2,3,1,1);
 
 		ErrorMetadata emd = MetadataFactory.createMetadata(ErrorMetadata.class);
-		ILazyDataset axisErr = Random.lazyRand(Dataset.INT32, "axis2_err", 2);
+		ILazyDataset axisErr = Random.lazyRand("axis2_err", IntegerDataset.class, 2);
 		emd.setError(axisErr);
 		axis.addMetadata(emd);
 
@@ -227,21 +227,21 @@ public class AxesMetadataTest {
 
 		int r = shape.length;
 
-		ILazyDataset axis = Random.lazyRand(Dataset.INT32, "axis", 2);
+		ILazyDataset axis = Random.lazyRand("axis", IntegerDataset.class, 2);
 		AxesMetadata amd = MetadataFactory.createMetadata(AxesMetadata.class, 1);
-		amd.setAxis(0, Random.lazyRand(Dataset.INT32, "axis2", 2));
+		amd.setAxis(0, Random.lazyRand("axis2", IntegerDataset.class, 2));
 		axis.addMetadata(amd);
 
 		amd = MetadataFactory.createMetadata(AxesMetadata.class, r);
 		amd.setAxis(1, axis);
-		ILazyDataset dataset = Random.lazyRand(Dataset.INT32, "Main", shape);
+		ILazyDataset dataset = Random.lazyRand("Main", IntegerDataset.class, shape);
 		dataset.addMetadata(amd);
-		ILazyDataset datasetErr = Random.lazyRand(Dataset.INT32, "dataset_err", 1, 2, 1, 1);
+		ILazyDataset datasetErr = Random.lazyRand("dataset_err", IntegerDataset.class, 1, 2, 1, 1);
 		dataset.setErrors(datasetErr);
 
 		dataset.setShape(2, 3, 1, 1);
 
-		ILazyDataset axisErr = Random.lazyRand(Dataset.INT32, "axis2_err", 2);
+		ILazyDataset axisErr = Random.lazyRand("axis2_err", IntegerDataset.class, 2);
 
 		amd = MetadataFactory.createMetadata(AxesMetadata.class, 1);
 		amd.setAxis(0, axis);
@@ -260,8 +260,8 @@ public class AxesMetadataTest {
 		final int[] shape = new int[] { 3, 10, 11 };
 		final int[] ashape = new int[] { 3 };
 
-		ILazyDataset dataset = Random.lazyRand(Dataset.INT32, "Main", shape);
-		ILazyDataset ax = Random.lazyRand(Dataset.INT32, "Axis", ashape);
+		ILazyDataset dataset = Random.lazyRand("Main", IntegerDataset.class, shape);
+		ILazyDataset ax = Random.lazyRand("Axis", IntegerDataset.class, ashape);
 
 		AxesMetadata amd = MetadataFactory.createMetadata(AxesMetadata.class, shape.length);
 		amd.setAxis(0, ax);
@@ -380,7 +380,7 @@ public class AxesMetadataTest {
 	public void testAxesMetadataScalar() throws MetadataException {
 		final int[] reshape = new int[] { 1, 1 };
 
-		ILazyDataset lazy = Random.lazyRand(Dataset.INT32, "Main");
+		ILazyDataset lazy = Random.lazyRand("Main", IntegerDataset.class);
 		AxesMetadata amd = MetadataFactory.createMetadata(AxesMetadata.class, 0);
 		lazy.addMetadata(amd);
 		lazy.setShape(reshape);

--- a/org.eclipse.january.test/src/org/eclipse/january/metadata/internal/SliceableMetadataTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/metadata/internal/SliceableMetadataTest.java
@@ -20,7 +20,6 @@ import java.util.Map;
 
 import org.eclipse.january.DatasetException;
 import org.eclipse.january.dataset.BooleanDataset;
-import org.eclipse.january.dataset.Dataset;
 import org.eclipse.january.dataset.DoubleDataset;
 import org.eclipse.january.dataset.IDataset;
 import org.eclipse.january.dataset.ILazyDataset;
@@ -41,17 +40,17 @@ public class SliceableMetadataTest {
 		final DoubleDataset[] dda = new DoubleDataset[] {Random.randn(shape), Random.randn(shape),};
 
 		List<ShortDataset> sdl = new ArrayList<>();
-		sdl.add((ShortDataset) Random.randn(shape).cast(Dataset.INT16));
-		sdl.add((ShortDataset) Random.randn(shape).cast(Dataset.INT16));
+		sdl.add(Random.randn(shape).cast(ShortDataset.class));
+		sdl.add(Random.randn(shape).cast(ShortDataset.class));
 
 		Map<String, BooleanDataset> bdm = new HashMap<String, BooleanDataset>();
-		bdm.put("1", (BooleanDataset) Random.randn(shape).cast(Dataset.BOOL));
-		bdm.put("2", (BooleanDataset) Random.randn(shape).cast(Dataset.BOOL));
-		
+		bdm.put("1", Random.randn(shape).cast(BooleanDataset.class));
+		bdm.put("2", Random.randn(shape).cast(BooleanDataset.class));
+
 		List<DoubleDataset[]> l2 = new ArrayList<DoubleDataset[]>();
 		l2.add(new DoubleDataset[]{Random.randn(shape)});
 		l2.add(new DoubleDataset[]{Random.randn(shape)});
-		
+
 		SliceableTestMetadata md = new SliceableTestMetadata(ld, dda, sdl, bdm, l2);
 
 		ILazyDataset dataset = Random.lazyRand("Main", IntegerDataset.class, shape);
@@ -239,18 +238,18 @@ public class SliceableMetadataTest {
 
 		final int [] partial2 = new int[] {1, 1, 3, 1};
 		List<ShortDataset> sdl = new ArrayList<>();
-		sdl.add((ShortDataset) Random.randn(partial2).cast(Dataset.INT16));
-		sdl.add((ShortDataset) Random.randn(partial2).cast(Dataset.INT16));
+		sdl.add(Random.randn(partial2).cast(ShortDataset.class));
+		sdl.add(Random.randn(partial2).cast(ShortDataset.class));
 
 		final int [] partial3 = new int[] {1, 2, 1, 1};
 		Map<String, BooleanDataset> bdm = new HashMap<String, BooleanDataset>();
-		bdm.put("1", (BooleanDataset) Random.randn(partial3).cast(Dataset.BOOL));
-		bdm.put("2", (BooleanDataset) Random.randn(partial3).cast(Dataset.BOOL));
+		bdm.put("1", Random.randn(partial3).cast(BooleanDataset.class));
+		bdm.put("2", Random.randn(partial3).cast(BooleanDataset.class));
 
 		List<DoubleDataset[]> l2 = new ArrayList<DoubleDataset[]>();
 		l2.add(new DoubleDataset[]{Random.randn(partial1)});
 		l2.add(new DoubleDataset[]{Random.randn(partial1)});
-		
+
 		SliceableTestMetadata md = new SliceableTestMetadata(ld, dda, sdl, bdm, l2);
 
 		ILazyDataset dataset = Random.lazyRand("Main", IntegerDataset.class, shape);
@@ -334,14 +333,14 @@ public class SliceableMetadataTest {
 
 		final int [] partial2 = new int[] {1, 1, 3, 4};
 		List<ShortDataset> sdl = new ArrayList<>();
-		sdl.add((ShortDataset) Random.randn(partial2).cast(Dataset.INT16));
-		sdl.add((ShortDataset) Random.randn(partial2).cast(Dataset.INT16));
+		sdl.add(Random.randn(partial2).cast(ShortDataset.class));
+		sdl.add(Random.randn(partial2).cast(ShortDataset.class));
 
 		final int [] partial3 = new int[] {1, 1, 1, 3};
 		Map<String, BooleanDataset> bdm = new HashMap<String, BooleanDataset>();
-		bdm.put("1", (BooleanDataset) Random.randn(partial3).cast(Dataset.BOOL));
-		bdm.put("2", (BooleanDataset) Random.randn(partial3).cast(Dataset.BOOL));
-		
+		bdm.put("1", Random.randn(partial3).cast(BooleanDataset.class));
+		bdm.put("2", Random.randn(partial3).cast(BooleanDataset.class));
+
 		List<DoubleDataset[]> l2 = new ArrayList<DoubleDataset[]>();
 		l2.add(new DoubleDataset[]{Random.randn(shape)});
 		l2.add(new DoubleDataset[]{Random.randn(shape)});
@@ -371,8 +370,8 @@ public class SliceableMetadataTest {
 
 		final int [] partial4 = new int[] {1, 2, 1, 1};
 		final int[] result3 = new int[] {1, 1, 1, 1};
-		bdm.put("1", (BooleanDataset) Random.randn(partial4).cast(Dataset.BOOL));
-		bdm.put("2", (BooleanDataset) Random.randn(partial4).cast(Dataset.BOOL));
+		bdm.put("1", Random.randn(partial4).cast(BooleanDataset.class));
+		bdm.put("2", Random.randn(partial4).cast(BooleanDataset.class));
 		sliced = dataset.getSliceView(slice);
 		assertArrayEquals(new int[] {1, 1, 3, 2}, sliced.getShape());
 		try {
@@ -401,13 +400,13 @@ public class SliceableMetadataTest {
 
 		final int [] partial2 = new int[] {1, 1, 3, 1};
 		List<ShortDataset> sdl = new ArrayList<>();
-		sdl.add((ShortDataset) Random.randn(partial2).cast(Dataset.INT16));
-		sdl.add((ShortDataset) Random.randn(partial2).cast(Dataset.INT16));
+		sdl.add(Random.randn(partial2).cast(ShortDataset.class));
+		sdl.add(Random.randn(partial2).cast(ShortDataset.class));
 
 		final int [] partial3 = new int[] {1, 2, 1, 1};
 		Map<String, BooleanDataset> bdm = new HashMap<String, BooleanDataset>();
-		bdm.put("1", (BooleanDataset) Random.randn(partial3).cast(Dataset.BOOL));
-		bdm.put("2", (BooleanDataset) Random.randn(partial3).cast(Dataset.BOOL));
+		bdm.put("1", Random.randn(partial3).cast(BooleanDataset.class));
+		bdm.put("2", Random.randn(partial3).cast(BooleanDataset.class));
 
 		List<DoubleDataset[]> l2 = new ArrayList<DoubleDataset[]>();
 		l2.add(new DoubleDataset[]{Random.randn(partial1)});
@@ -450,7 +449,7 @@ public class SliceableMetadataTest {
 			fail("Should not fail: " + e);
 		}
 
-		dataset = Random.randn(shape).cast(Dataset.INT32);
+		dataset = Random.randn(shape).cast(IntegerDataset.class);
 		md = new SliceableTestMetadata(null, dda, sdl, bdm, l2);
 		dataset.addMetadata(md);
 		try {

--- a/org.eclipse.january.test/src/org/eclipse/january/metadata/internal/SliceableMetadataTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/metadata/internal/SliceableMetadataTest.java
@@ -24,6 +24,7 @@ import org.eclipse.january.dataset.Dataset;
 import org.eclipse.january.dataset.DoubleDataset;
 import org.eclipse.january.dataset.IDataset;
 import org.eclipse.january.dataset.ILazyDataset;
+import org.eclipse.january.dataset.IntegerDataset;
 import org.eclipse.january.dataset.Random;
 import org.eclipse.january.dataset.ShortDataset;
 import org.eclipse.january.dataset.Slice;
@@ -35,7 +36,7 @@ public class SliceableMetadataTest {
 	@Test
 	public void testSlicingMetadata() {
 		final int[] shape = new int[] {1, 2, 3, 4};
-		ILazyDataset ld = Random.lazyRand(Dataset.INT32, "Metadata1", shape);
+		ILazyDataset ld = Random.lazyRand("Metadata1", IntegerDataset.class, shape);
 
 		final DoubleDataset[] dda = new DoubleDataset[] {Random.randn(shape), Random.randn(shape),};
 
@@ -53,7 +54,7 @@ public class SliceableMetadataTest {
 		
 		SliceableTestMetadata md = new SliceableTestMetadata(ld, dda, sdl, bdm, l2);
 
-		ILazyDataset dataset = Random.lazyRand(Dataset.INT32, "Main", shape);
+		ILazyDataset dataset = Random.lazyRand("Main", IntegerDataset.class, shape);
 		dataset.addMetadata(md);
 
 		try {
@@ -156,10 +157,10 @@ public class SliceableMetadataTest {
 		
 		final int[] bshape = new int[] {1, 5, 1};
 		final int[] shape = new int[] {4, 5, 6};
-		ILazyDataset ld = Random.lazyRand(Dataset.INT32, "Metadata1", bshape);
+		ILazyDataset ld = Random.lazyRand("Metadata1", IntegerDataset.class, bshape);
 		SliceableTestMetadata md = new SliceableTestMetadata(ld, null, null, null, null);
 
-		ILazyDataset dataset = Random.lazyRand(Dataset.INT32, "Main", shape);
+		ILazyDataset dataset = Random.lazyRand("Main", IntegerDataset.class, shape);
 		dataset.addMetadata(md);
 		
 		try {
@@ -178,10 +179,10 @@ public class SliceableMetadataTest {
 	@Test
 	public void testSlicingSqueezedMetadata() throws DatasetException {
 		final int[] shape = new int[] {1, 1, 128};
-		ILazyDataset ld = Random.lazyRand(Dataset.INT32, "Metadata1", shape);
+		ILazyDataset ld = Random.lazyRand("Metadata1", IntegerDataset.class, shape);
 		SliceableTestMetadata md = new SliceableTestMetadata(ld, null, null, null, null);
 
-		ILazyDataset dataset = Random.lazyRand(Dataset.INT32, "Main", shape);
+		ILazyDataset dataset = Random.lazyRand("Main", IntegerDataset.class, shape);
 		dataset.addMetadata(md);
 
 		Slice[] slice = new Slice[] {null, null, new Slice(64)};
@@ -231,7 +232,7 @@ public class SliceableMetadataTest {
 		final int[] result2 = new int[] {1, 1, 3, 1};
 		
 		final int[] shape = new int[] {1, 2, 3, 4};
-		ILazyDataset ld = Random.lazyRand(Dataset.INT32, "Metadata1", shape);
+		ILazyDataset ld = Random.lazyRand("Metadata1", IntegerDataset.class, shape);
 
 		final int [] partial1 = new int[] {1, 1, 1, 4};
 		final DoubleDataset[] dda = new DoubleDataset[] {Random.randn(partial1), Random.randn(partial1),};
@@ -252,7 +253,7 @@ public class SliceableMetadataTest {
 		
 		SliceableTestMetadata md = new SliceableTestMetadata(ld, dda, sdl, bdm, l2);
 
-		ILazyDataset dataset = Random.lazyRand(Dataset.INT32, "Main", shape);
+		ILazyDataset dataset = Random.lazyRand("Main", IntegerDataset.class, shape);
 		dataset.addMetadata(md);
 		
 		try {
@@ -326,7 +327,7 @@ public class SliceableMetadataTest {
 		final int[] result2 = new int[] {1, 1, 3, 2};
 		
 		final int[] shape = new int[] {1, 2, 3, 4};
-		ILazyDataset ld = Random.lazyRand(Dataset.INT32, "Metadata1", shape);
+		ILazyDataset ld = Random.lazyRand("Metadata1", IntegerDataset.class, shape);
 
 		final int [] partial1 = new int[] {1, 1, 1, 4};
 		final DoubleDataset[] dda = new DoubleDataset[] {Random.randn(partial1), Random.randn(partial1),};
@@ -347,7 +348,7 @@ public class SliceableMetadataTest {
 
 		SliceableTestMetadata md = new SliceableTestMetadata(ld, dda, sdl, bdm, l2);
 
-		ILazyDataset dataset = Random.lazyRand(Dataset.INT32, "Main", shape);
+		ILazyDataset dataset = Random.lazyRand("Main", IntegerDataset.class, shape);
 		dataset.addMetadata(md);
 		
 		try {
@@ -393,7 +394,7 @@ public class SliceableMetadataTest {
 	public void testSlicingSameRankDifferentShapeSqueezeMetadata() {
 		
 		final int[] shape = new int[] {1, 2, 3, 4};
-		ILazyDataset ld = Random.lazyRand(Dataset.INT32, "Metadata1", shape);
+		ILazyDataset ld = Random.lazyRand("Metadata1", IntegerDataset.class, shape);
 
 		final int [] partial1 = new int[] {1, 1, 1, 4};
 		final DoubleDataset[] dda = new DoubleDataset[] {Random.randn(partial1), Random.randn(partial1),};
@@ -414,7 +415,7 @@ public class SliceableMetadataTest {
 		
 		SliceableTestMetadata md = new SliceableTestMetadata(ld, dda, sdl, bdm, l2);
 
-		ILazyDataset dataset = Random.lazyRand(Dataset.INT32, "Main", shape);
+		ILazyDataset dataset = Random.lazyRand("Main", IntegerDataset.class, shape);
 		dataset.addMetadata(md);
 		
 		try {

--- a/org.eclipse.january/.settings/.api_filters
+++ b/org.eclipse.january/.settings/.api_filters
@@ -38,6 +38,12 @@
         <filter id="338755678">
             <message_arguments>
                 <message_argument value="org.eclipse.january.dataset.LazyDataset"/>
+                <message_argument value="dtype"/>
+            </message_arguments>
+        </filter>
+        <filter id="338755678">
+            <message_arguments>
+                <message_argument value="org.eclipse.january.dataset.LazyDataset"/>
                 <message_argument value="postShape"/>
             </message_arguments>
         </filter>

--- a/org.eclipse.january/.settings/.api_filters
+++ b/org.eclipse.january/.settings/.api_filters
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <component id="org.eclipse.january" version="2">
     <resource path="META-INF/MANIFEST.MF">
-        <filter id="923795461">
+        <filter id="931135546">
             <message_arguments>
-                <message_argument value="2.3.0"/>
+                <message_argument value="2.3.1"/>
                 <message_argument value="2.2.0"/>
             </message_arguments>
         </filter>
@@ -13,6 +13,20 @@
             <message_arguments>
                 <message_argument value="org.eclipse.january.dataset.Dataset"/>
                 <message_argument value="cast(int, Class&lt;T&gt;, boolean)"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="src/org/eclipse/january/dataset/DatasetFactory.java" type="org.eclipse.january.dataset.DatasetFactory">
+        <filter id="338792546">
+            <message_arguments>
+                <message_argument value="org.eclipse.january.dataset.DatasetFactory"/>
+                <message_argument value="createComplexDataset(Class&lt;T&gt;, Object, Object)"/>
+            </message_arguments>
+        </filter>
+        <filter id="338792546">
+            <message_arguments>
+                <message_argument value="org.eclipse.january.dataset.DatasetFactory"/>
+                <message_argument value="createCompoundDataset(Class&lt;T&gt;, Object[])"/>
             </message_arguments>
         </filter>
     </resource>
@@ -74,6 +88,14 @@
             </message_arguments>
         </filter>
     </resource>
+    <resource path="src/org/eclipse/january/dataset/LazyDatasetBase.java" type="org.eclipse.january.dataset.LazyDatasetBase">
+        <filter id="338792546">
+            <message_arguments>
+                <message_argument value="org.eclipse.january.dataset.LazyDatasetBase"/>
+                <message_argument value="getElementClass()"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="src/org/eclipse/january/dataset/LazyDynamicDataset.java" type="org.eclipse.january.dataset.LazyDynamicDataset">
         <filter id="1141899266">
             <message_arguments>
@@ -89,6 +111,47 @@
                 <message_argument value="2.2"/>
                 <message_argument value="2.3"/>
                 <message_argument value="LazyWriteableDataset(LazyWriteableDataset)"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="src/org/eclipse/january/dataset/RGBDataset.java" type="org.eclipse.january.dataset.RGBDataset">
+        <filter id="338792546">
+            <message_arguments>
+                <message_argument value="org.eclipse.january.dataset.RGBDataset"/>
+                <message_argument value="createBlueDataset(T)"/>
+            </message_arguments>
+        </filter>
+        <filter id="338792546">
+            <message_arguments>
+                <message_argument value="org.eclipse.january.dataset.RGBDataset"/>
+                <message_argument value="createGreenDataset(T)"/>
+            </message_arguments>
+        </filter>
+        <filter id="338792546">
+            <message_arguments>
+                <message_argument value="org.eclipse.january.dataset.RGBDataset"/>
+                <message_argument value="createRedDataset(T)"/>
+            </message_arguments>
+        </filter>
+        <filter id="1141899266">
+            <message_arguments>
+                <message_argument value="2.1"/>
+                <message_argument value="2.3"/>
+                <message_argument value="createBlueDataset(Class&lt;T&gt;)"/>
+            </message_arguments>
+        </filter>
+        <filter id="1141899266">
+            <message_arguments>
+                <message_argument value="2.1"/>
+                <message_argument value="2.3"/>
+                <message_argument value="createGreenDataset(Class&lt;T&gt;)"/>
+            </message_arguments>
+        </filter>
+        <filter id="1141899266">
+            <message_arguments>
+                <message_argument value="2.1"/>
+                <message_argument value="2.3"/>
+                <message_argument value="createRedDataset(Class&lt;T&gt;)"/>
             </message_arguments>
         </filter>
     </resource>

--- a/org.eclipse.january/META-INF/MANIFEST.MF
+++ b/org.eclipse.january/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse January Datasets (Incubation)
 Bundle-SymbolicName: org.eclipse.january
-Bundle-Version: 2.3.0.qualifier
+Bundle-Version: 2.3.0
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Export-Package: org.eclipse.january;version="2.3.0",
  org.eclipse.january.dataset;version="2.3.0",

--- a/org.eclipse.january/META-INF/MANIFEST.MF
+++ b/org.eclipse.january/META-INF/MANIFEST.MF
@@ -2,13 +2,13 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse January Datasets (Incubation)
 Bundle-SymbolicName: org.eclipse.january
-Bundle-Version: 2.3.0
+Bundle-Version: 2.3.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
-Export-Package: org.eclipse.january;version="2.3.0",
- org.eclipse.january.dataset;version="2.3.0",
- org.eclipse.january.io;version="2.3.0",
- org.eclipse.january.metadata;version="2.3.0",
- org.eclipse.january.metadata.internal;version="2.3.0";x-internal:=true
+Export-Package: org.eclipse.january;version="2.3.1",
+ org.eclipse.january.dataset;version="2.3.1",
+ org.eclipse.january.io;version="2.3.1",
+ org.eclipse.january.metadata;version="2.3.1",
+ org.eclipse.january.metadata.internal;version="2.3.1";x-internal:=true
 Require-Bundle: org.apache.commons.math3;bundle-version="[3.2.0,4.0.0)";visibility:=reexport,
  javax.measure.unit-api;bundle-version="[1.0.0,2.0.0)";visibility:=reexport
 Import-Package: org.slf4j;version="[1.7.2,2.0.0)"

--- a/org.eclipse.january/pom.xml
+++ b/org.eclipse.january/pom.xml
@@ -14,12 +14,12 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>org.eclipse.january</artifactId>
-	<version>2.3.0-SNAPSHOT</version>
+	<version>2.3.0</version>
 	<parent>
 		<relativePath>../releng/org.eclipse.january.releng/pom.xml</relativePath>
 		<groupId>org.eclipse.january</groupId>
 		<artifactId>org.eclipse.january.releng</artifactId>
-		<version>2.3.0-SNAPSHOT</version>
+		<version>2.3.0</version>
 	</parent>
 	<packaging>eclipse-plugin</packaging>
 

--- a/org.eclipse.january/pom.xml
+++ b/org.eclipse.january/pom.xml
@@ -14,12 +14,12 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>org.eclipse.january</artifactId>
-	<version>2.3.0</version>
+	<version>2.3.1-SNAPSHOT</version>
 	<parent>
 		<relativePath>../releng/org.eclipse.january.releng/pom.xml</relativePath>
 		<groupId>org.eclipse.january</groupId>
 		<artifactId>org.eclipse.january.releng</artifactId>
-		<version>2.3.0</version>
+		<version>2.3.1-SNAPSHOT</version>
 	</parent>
 	<packaging>eclipse-plugin</packaging>
 

--- a/org.eclipse.january/src/org/eclipse/january/dataset/AbstractCompoundDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/AbstractCompoundDataset.java
@@ -99,6 +99,16 @@ public abstract class AbstractCompoundDataset extends AbstractDataset implements
 
 	@Override
 	public IndexIterator getSliceIterator(SliceND slice) {
+		checkSliceND(slice);
+		return internalGetSliceIterator(slice);
+	}
+
+	/**
+	 * @param slice
+	 * @return an slice iterator that operates like an IndexIterator
+	 */
+	@Override
+	protected IndexIterator internalGetSliceIterator(SliceND slice) {
 		if (ShapeUtils.calcLongSize(slice.getShape()) == 0) {
 			return new NullIterator(shape, slice.getShape());
 		}

--- a/org.eclipse.january/src/org/eclipse/january/dataset/AbstractCompoundDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/AbstractCompoundDataset.java
@@ -18,6 +18,8 @@ import org.eclipse.january.DatasetException;
 import org.eclipse.january.IMonitor;
 import org.eclipse.january.metadata.StatisticsMetadata;
 import org.eclipse.january.metadata.internal.StatisticsMetadataImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Generic container class for data that is compound in nature
@@ -30,6 +32,8 @@ import org.eclipse.january.metadata.internal.StatisticsMetadataImpl;
 public abstract class AbstractCompoundDataset extends AbstractDataset implements CompoundDataset {
 	// pin UID to base class
 	private static final long serialVersionUID = Dataset.serialVersionUID;
+
+	private static final Logger logger = LoggerFactory.getLogger(AbstractCompoundDataset.class);
 
 	protected int isize; // number of elements per item
 

--- a/org.eclipse.january/src/org/eclipse/january/dataset/AbstractDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/AbstractDataset.java
@@ -26,6 +26,8 @@ import org.eclipse.january.metadata.MetadataFactory;
 import org.eclipse.january.metadata.StatisticsMetadata;
 import org.eclipse.january.metadata.internal.ErrorMetadataImpl;
 import org.eclipse.january.metadata.internal.StatisticsMetadataImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Generic container class for data 
@@ -38,6 +40,8 @@ import org.eclipse.january.metadata.internal.StatisticsMetadataImpl;
 public abstract class AbstractDataset extends LazyDatasetBase implements Dataset {
 	// pin UID to base class
 	private static final long serialVersionUID = Dataset.serialVersionUID;
+
+	private static final Logger logger = LoggerFactory.getLogger(AbstractDataset.class);
 
 	protected int size; // number of items
 

--- a/org.eclipse.january/src/org/eclipse/january/dataset/AbstractDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/AbstractDataset.java
@@ -339,7 +339,7 @@ public abstract class AbstractDataset extends LazyDatasetBase implements Dataset
 
 	@Override
 	public IndexIterator getSliceIterator(final int[] start, final int[] stop, final int[] step) {
-		return getSliceIterator(new SliceND(shape, start, stop, step));
+		return internalGetSliceIterator(new SliceND(shape, start, stop, step));
 	}
 
 	/**
@@ -347,6 +347,15 @@ public abstract class AbstractDataset extends LazyDatasetBase implements Dataset
 	 * @return an slice iterator that operates like an IndexIterator
 	 */
 	public IndexIterator getSliceIterator(SliceND slice) {
+		checkSliceND(slice);
+		return internalGetSliceIterator(slice);
+	}
+
+	/**
+	 * @param slice
+	 * @return an slice iterator that operates like an IndexIterator
+	 */
+	protected IndexIterator internalGetSliceIterator(SliceND slice) {
 		if (ShapeUtils.calcLongSize(slice.getShape()) == 0) {
 			return new NullIterator(shape, slice.getShape());
 		}
@@ -777,7 +786,7 @@ public abstract class AbstractDataset extends LazyDatasetBase implements Dataset
 
 	@Override
 	public Dataset getSliceView(final int[] start, final int[] stop, final int[] step) {
-		return getSliceView(new SliceND(shape, start, stop, step));
+		return internalGetSliceView(new SliceND(shape, start, stop, step));
 	}
 
 	@Override
@@ -786,7 +795,7 @@ public abstract class AbstractDataset extends LazyDatasetBase implements Dataset
 			return getView(true);
 		}
 
-		return getSliceView(new SliceND(shape, slice));
+		return internalGetSliceView(new SliceND(shape, slice));
 	}
 
 	/**
@@ -796,6 +805,11 @@ public abstract class AbstractDataset extends LazyDatasetBase implements Dataset
 	 */
 	@Override
 	public Dataset getSliceView(SliceND slice) {
+		checkSliceND(slice);
+		return internalGetSliceView(slice);
+	}
+
+	private Dataset internalGetSliceView(SliceND slice) {
 		if (slice.isAll()) {
 			return getView(true);
 		}
@@ -1371,12 +1385,12 @@ public abstract class AbstractDataset extends LazyDatasetBase implements Dataset
 
 	@Override
 	public Dataset getSlice(final int[] start, final int[] stop, final int[] step) {
-		return getSlice(new SliceND(shape, start, stop, step));
+		return internalGetSlice(new SliceND(shape, start, stop, step));
 	}
 
 	@Override
 	public Dataset getSlice(Slice... slice) {
-		return getSlice(new SliceND(shape, slice));
+		return internalGetSlice(new SliceND(shape, slice));
 	}
 
 	@Override
@@ -1401,7 +1415,12 @@ public abstract class AbstractDataset extends LazyDatasetBase implements Dataset
 	 */
 	@Override
 	public Dataset getSlice(final SliceND slice) {
-		SliceIterator it = (SliceIterator) getSliceIterator(slice);
+		checkSliceND(slice);
+		return internalGetSlice(slice);
+	}
+
+	private Dataset internalGetSlice(final SliceND slice) {
+		SliceIterator it = (SliceIterator) internalGetSliceIterator(slice);
 		AbstractDataset s = getSlice(it);
 		s.metadata = copyMetadata();
 		s.setDirty();
@@ -1419,6 +1438,11 @@ public abstract class AbstractDataset extends LazyDatasetBase implements Dataset
 
 	@Override
 	public Dataset setSlice(final Object obj, final SliceND slice) {
+		checkSliceND(slice);
+		return internalSetSlice(obj, slice);
+	}
+
+	private Dataset internalSetSlice(final Object obj, final SliceND slice) {
 		Dataset ds;
 		if (obj instanceof Dataset) {
 			ds = (Dataset) obj;
@@ -1437,7 +1461,7 @@ public abstract class AbstractDataset extends LazyDatasetBase implements Dataset
 
 	@Override
 	public Dataset setSlice(final Object obj, final int[] start, final int[] stop, final int[] step) {
-		return setSlice(obj, new SliceND(shape, start, stop, step));
+		return internalSetSlice(obj, new SliceND(shape, start, stop, step));
 	}
 
 	/**
@@ -1451,9 +1475,9 @@ public abstract class AbstractDataset extends LazyDatasetBase implements Dataset
 	@Override
 	public Dataset setSlice(Object obj, Slice... slice) {
 		if (slice == null || slice.length == 0) {
-			return setSlice(obj, new SliceND(shape));
+			return internalSetSlice(obj, new SliceND(shape));
 		}
-		return setSlice(obj, new SliceND(shape, slice));
+		return internalSetSlice(obj, new SliceND(shape, slice));
 	}
 
 	@Override

--- a/org.eclipse.january/src/org/eclipse/january/dataset/AbstractDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/AbstractDataset.java
@@ -306,9 +306,9 @@ public abstract class AbstractDataset extends LazyDatasetBase implements Dataset
 				new SingleItemIterator(offset, size)) : new StrideIterator(shape, stride, offset);
 		}
 		if (shape == null) {
-			return new NullIterator(shape, shape);
+			return new NullIterator();
 		}
-		
+
 		return withPosition ? new ContiguousIteratorWithPosition(shape, size) : new ContiguousIterator(size);
 	}
 
@@ -476,6 +476,13 @@ public abstract class AbstractDataset extends LazyDatasetBase implements Dataset
 	 * @param size
 	 */
 	private void checkShape(int[] shape, int size) {
+		if (shape == null) {
+			if (size == 0) {
+				return;
+			}
+			logger.error("New shape must not be null for nonzero-sized dataset");
+			throw new IllegalArgumentException("New shape must not be null for nonzero-sized dataset");
+		}
 		int rank = shape.length;
 		int found = -1;
 		int nsize = 1;
@@ -502,7 +509,7 @@ public abstract class AbstractDataset extends LazyDatasetBase implements Dataset
 
 	@Override
 	public void setShape(final int... shape) {
-		int[] nshape = shape.clone();
+		int[] nshape = shape == null ? null : shape.clone();
 		checkShape(nshape, size);
 		if (Arrays.equals(this.shape, nshape)) {
 			return;

--- a/org.eclipse.january/src/org/eclipse/january/dataset/AbstractDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/AbstractDataset.java
@@ -1586,7 +1586,7 @@ public abstract class AbstractDataset extends LazyDatasetBase implements Dataset
 
 	@Override
 	public Object sum(boolean... ignoreInvalids) {
-		return getStats().getSum(ignoreInvalids);
+		return InterfaceUtils.toBiggestNumber(getClass(), getStats().getSum(ignoreInvalids));
 	}
 
 	@Override

--- a/org.eclipse.january/src/org/eclipse/january/dataset/BooleanDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/BooleanDataset.java
@@ -14,6 +14,9 @@ package org.eclipse.january.dataset;
 
 import java.text.MessageFormat;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 /**
  * Extend boolean base dataset for boolean values
@@ -21,6 +24,8 @@ import java.text.MessageFormat;
 public class BooleanDataset extends BooleanDatasetBase {
 	// pin UID to base class
 	private static final long serialVersionUID = Dataset.serialVersionUID;
+
+	private static final Logger logger = LoggerFactory.getLogger(BooleanDataset.class);
 
 	/**
 	 * Create a null dataset

--- a/org.eclipse.january/src/org/eclipse/january/dataset/BooleanDatasetBase.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/BooleanDatasetBase.java
@@ -21,6 +21,8 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import org.eclipse.january.metadata.StatisticsMetadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -29,6 +31,8 @@ import org.eclipse.january.metadata.StatisticsMetadata;
 public class BooleanDatasetBase extends AbstractDataset {
 	// pin UID to base class
 	private static final long serialVersionUID = Dataset.serialVersionUID;
+
+	private static final Logger logger = LoggerFactory.getLogger(BooleanDatasetBase.class);
 
 	protected boolean[] data; // subclass alias // PRIM_TYPE
 

--- a/org.eclipse.january/src/org/eclipse/january/dataset/BooleanDatasetBase.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/BooleanDatasetBase.java
@@ -51,11 +51,6 @@ public class BooleanDatasetBase extends AbstractDataset {
 		return array;
 	}
 
-	@Override
-	public int getDType() {
-		return BOOL; // DATA_TYPE
-	}
-
 	/**
 	 * Create a null dataset
 	 */

--- a/org.eclipse.january/src/org/eclipse/january/dataset/BroadcastIterator.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/BroadcastIterator.java
@@ -59,7 +59,7 @@ public abstract class BroadcastIterator extends BroadcastIteratorBase {
 		oDataset = o;
 		outputA = a == o;
 		outputB = b == o;
-		read = DTypeUtils.isDTypeNumerical(a.getDType()) && DTypeUtils.isDTypeNumerical(b.getDType());
+		read = InterfaceUtils.isNumerical(a.getClass()) && InterfaceUtils.isNumerical(b.getClass());
 		asDouble = aDataset.hasFloatingPointElements() || bDataset.hasFloatingPointElements();
 		BroadcastUtils.checkItemSize(a, b, o);
 		if (o != null) {

--- a/org.eclipse.january/src/org/eclipse/january/dataset/BroadcastSelfIterator.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/BroadcastSelfIterator.java
@@ -27,7 +27,7 @@ public abstract class BroadcastSelfIterator extends BroadcastIteratorBase {
 
 	protected BroadcastSelfIterator(Dataset a, Dataset b) {
 		super(a, b);
-		read = DTypeUtils.isDTypeNumerical(b.getDType());
+		read = InterfaceUtils.isNumerical(b.getClass());
 		asDouble = aDataset.hasFloatingPointElements();
 		BroadcastUtils.checkItemSize(a, b, null);
 	}

--- a/org.eclipse.january/src/org/eclipse/january/dataset/BroadcastUtils.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/BroadcastUtils.java
@@ -253,7 +253,7 @@ public final class BroadcastUtils {
 				throw new IllegalArgumentException("Can not broadcast where number of elements per item mismatch and one does not equal another");
 			}
 		}
-		if (o != null && o.getDType() != Dataset.BOOL) {
+		if (o != null && BooleanDataset.class.isAssignableFrom(o.getClass())) {
 			final int ism = Math.max(isa, isb);
 			final int iso = o.getElementsPerItem();
 			if (iso != ism && iso != 1 && ism != 1) {

--- a/org.eclipse.january/src/org/eclipse/january/dataset/ByteDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/ByteDataset.java
@@ -22,6 +22,8 @@ import java.util.TreeSet;
 
 import org.apache.commons.math3.complex.Complex;
 import org.eclipse.january.metadata.StatisticsMetadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -30,6 +32,8 @@ import org.eclipse.january.metadata.StatisticsMetadata;
 public class ByteDataset extends AbstractDataset {
 	// pin UID to base class
 	private static final long serialVersionUID = Dataset.serialVersionUID;
+
+	private static final Logger logger = LoggerFactory.getLogger(ByteDataset.class);
 
 	protected byte[] data; // subclass alias // PRIM_TYPE
 

--- a/org.eclipse.january/src/org/eclipse/january/dataset/ByteDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/ByteDataset.java
@@ -52,11 +52,6 @@ public class ByteDataset extends AbstractDataset {
 		return array;
 	}
 
-	@Override
-	public int getDType() {
-		return INT8; // DATA_TYPE
-	}
-
 	/**
 	 * Create a null dataset
 	 */

--- a/org.eclipse.january/src/org/eclipse/january/dataset/ComplexDoubleDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/ComplexDoubleDataset.java
@@ -29,11 +29,6 @@ public class ComplexDoubleDataset extends CompoundDoubleDataset { // CLASS_TYPE
 
 	private static final int ISIZE = 2; // number of elements per item
 
-	@Override
-	public int getDType() {
-		return Dataset.COMPLEX128; // DATA_TYPE
-	}
-
 	/**
 	 * Create a null dataset
 	 */
@@ -208,6 +203,11 @@ public class ComplexDoubleDataset extends CompoundDoubleDataset { // CLASS_TYPE
 	 */
 	static ComplexDoubleDataset ones(final int... shape) {
 		return new ComplexDoubleDataset(shape).fill(1);
+	}
+
+	@Override
+	public boolean isComplex() {
+		return true;
 	}
 
 	@Override

--- a/org.eclipse.january/src/org/eclipse/january/dataset/ComplexDoubleDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/ComplexDoubleDataset.java
@@ -18,6 +18,8 @@ package org.eclipse.january.dataset;
 import java.util.Arrays;
 
 import org.apache.commons.math3.complex.Complex;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -26,6 +28,8 @@ import org.apache.commons.math3.complex.Complex;
 public class ComplexDoubleDataset extends CompoundDoubleDataset { // CLASS_TYPE
 	// pin UID to base class
 	private static final long serialVersionUID = Dataset.serialVersionUID;
+
+	private static final Logger logger = LoggerFactory.getLogger(ComplexDoubleDataset.class);
 
 	private static final int ISIZE = 2; // number of elements per item
 

--- a/org.eclipse.january/src/org/eclipse/january/dataset/ComplexFloatDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/ComplexFloatDataset.java
@@ -29,11 +29,6 @@ public class ComplexFloatDataset extends CompoundFloatDataset { // CLASS_TYPE
 
 	private static final int ISIZE = 2; // number of elements per item
 
-	@Override
-	public int getDType() {
-		return Dataset.COMPLEX64; // DATA_TYPE
-	}
-
 	/**
 	 * Create a null dataset
 	 */
@@ -208,6 +203,11 @@ public class ComplexFloatDataset extends CompoundFloatDataset { // CLASS_TYPE
 	 */
 	static ComplexFloatDataset ones(final int... shape) {
 		return new ComplexFloatDataset(shape).fill(1);
+	}
+
+	@Override
+	public boolean isComplex() {
+		return true;
 	}
 
 	@Override

--- a/org.eclipse.january/src/org/eclipse/january/dataset/ComplexFloatDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/ComplexFloatDataset.java
@@ -18,6 +18,8 @@ package org.eclipse.january.dataset;
 import java.util.Arrays;
 
 import org.apache.commons.math3.complex.Complex;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -26,6 +28,8 @@ import org.apache.commons.math3.complex.Complex;
 public class ComplexFloatDataset extends CompoundFloatDataset { // CLASS_TYPE
 	// pin UID to base class
 	private static final long serialVersionUID = Dataset.serialVersionUID;
+
+	private static final Logger logger = LoggerFactory.getLogger(ComplexFloatDataset.class);
 
 	private static final int ISIZE = 2; // number of elements per item
 

--- a/org.eclipse.january/src/org/eclipse/january/dataset/CompoundByteDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/CompoundByteDataset.java
@@ -46,11 +46,6 @@ public class CompoundByteDataset extends AbstractCompoundDataset {
 		return array;
 	}
 
-	@Override
-	public int getDType() {
-		return Dataset.ARRAYINT8; // DATA_TYPE
-	}
-
 	/**
 	 * Create a null dataset
 	 */
@@ -378,7 +373,7 @@ public class CompoundByteDataset extends AbstractCompoundDataset {
 			logger.error("Need a single-element dataset");
 			throw new IllegalArgumentException("Need a single-element dataset");
 		}
-		if (a.getDType() != Dataset.INT8) { // DATA_TYPE
+		if (!ByteDataset.class.isAssignableFrom(a.getClass())) { // CLASS_TYPE
 			logger.error("Dataset type must be byte"); // PRIM_TYPE
 			throw new IllegalArgumentException("Dataset type must be byte"); // PRIM_TYPE
 		}

--- a/org.eclipse.january/src/org/eclipse/january/dataset/CompoundByteDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/CompoundByteDataset.java
@@ -17,6 +17,8 @@ package org.eclipse.january.dataset;
 import java.util.Arrays;
 
 import org.apache.commons.math3.complex.Complex;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Extend compound dataset for byte values // PRIM_TYPE
@@ -24,6 +26,8 @@ import org.apache.commons.math3.complex.Complex;
 public class CompoundByteDataset extends AbstractCompoundDataset {
 	// pin UID to base class
 	private static final long serialVersionUID = Dataset.serialVersionUID;
+
+	private static final Logger logger = LoggerFactory.getLogger(CompoundByteDataset.class);
 
 	protected byte[] data; // subclass alias // PRIM_TYPE
 

--- a/org.eclipse.january/src/org/eclipse/january/dataset/CompoundDoubleDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/CompoundDoubleDataset.java
@@ -17,6 +17,8 @@ package org.eclipse.january.dataset;
 import java.util.Arrays;
 
 import org.apache.commons.math3.complex.Complex;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Extend compound dataset for double values // PRIM_TYPE
@@ -24,6 +26,8 @@ import org.apache.commons.math3.complex.Complex;
 public class CompoundDoubleDataset extends AbstractCompoundDataset {
 	// pin UID to base class
 	private static final long serialVersionUID = Dataset.serialVersionUID;
+
+	private static final Logger logger = LoggerFactory.getLogger(CompoundDoubleDataset.class);
 
 	protected double[] data; // subclass alias // PRIM_TYPE
 

--- a/org.eclipse.january/src/org/eclipse/january/dataset/CompoundDoubleDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/CompoundDoubleDataset.java
@@ -46,11 +46,6 @@ public class CompoundDoubleDataset extends AbstractCompoundDataset {
 		return array;
 	}
 
-	@Override
-	public int getDType() {
-		return Dataset.ARRAYFLOAT64; // DATA_TYPE
-	}
-
 	/**
 	 * Create a null dataset
 	 */
@@ -378,7 +373,7 @@ public class CompoundDoubleDataset extends AbstractCompoundDataset {
 			logger.error("Need a single-element dataset");
 			throw new IllegalArgumentException("Need a single-element dataset");
 		}
-		if (a.getDType() != Dataset.FLOAT64) { // DATA_TYPE
+		if (!DoubleDataset.class.isAssignableFrom(a.getClass())) { // CLASS_TYPE
 			logger.error("Dataset type must be double"); // PRIM_TYPE 
 			throw new IllegalArgumentException("Dataset type must be double"); // PRIM_TYPE 
 		}

--- a/org.eclipse.january/src/org/eclipse/january/dataset/CompoundFloatDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/CompoundFloatDataset.java
@@ -17,6 +17,8 @@ package org.eclipse.january.dataset;
 import java.util.Arrays;
 
 import org.apache.commons.math3.complex.Complex;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Extend compound dataset for float values // PRIM_TYPE
@@ -24,6 +26,8 @@ import org.apache.commons.math3.complex.Complex;
 public class CompoundFloatDataset extends AbstractCompoundDataset {
 	// pin UID to base class
 	private static final long serialVersionUID = Dataset.serialVersionUID;
+
+	private static final Logger logger = LoggerFactory.getLogger(CompoundFloatDataset.class);
 
 	protected float[] data; // subclass alias // PRIM_TYPE
 

--- a/org.eclipse.january/src/org/eclipse/january/dataset/CompoundFloatDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/CompoundFloatDataset.java
@@ -46,11 +46,6 @@ public class CompoundFloatDataset extends AbstractCompoundDataset {
 		return array;
 	}
 
-	@Override
-	public int getDType() {
-		return Dataset.ARRAYFLOAT32; // DATA_TYPE
-	}
-
 	/**
 	 * Create a null dataset
 	 */
@@ -378,7 +373,7 @@ public class CompoundFloatDataset extends AbstractCompoundDataset {
 			logger.error("Need a single-element dataset");
 			throw new IllegalArgumentException("Need a single-element dataset");
 		}
-		if (a.getDType() != Dataset.FLOAT32) { // DATA_TYPE
+		if (!FloatDataset.class.isAssignableFrom(a.getClass())) { // CLASS_TYPE
 			logger.error("Dataset type must be float"); // PRIM_TYPE
 			throw new IllegalArgumentException("Dataset type must be float"); // PRIM_TYPE
 		}

--- a/org.eclipse.january/src/org/eclipse/january/dataset/CompoundIntegerDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/CompoundIntegerDataset.java
@@ -17,6 +17,8 @@ package org.eclipse.january.dataset;
 import java.util.Arrays;
 
 import org.apache.commons.math3.complex.Complex;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Extend compound dataset for int values // PRIM_TYPE
@@ -24,6 +26,8 @@ import org.apache.commons.math3.complex.Complex;
 public class CompoundIntegerDataset extends AbstractCompoundDataset {
 	// pin UID to base class
 	private static final long serialVersionUID = Dataset.serialVersionUID;
+
+	private static final Logger logger = LoggerFactory.getLogger(CompoundIntegerDataset.class);
 
 	protected int[] data; // subclass alias // PRIM_TYPE
 

--- a/org.eclipse.january/src/org/eclipse/january/dataset/CompoundIntegerDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/CompoundIntegerDataset.java
@@ -46,11 +46,6 @@ public class CompoundIntegerDataset extends AbstractCompoundDataset {
 		return array;
 	}
 
-	@Override
-	public int getDType() {
-		return Dataset.ARRAYINT32; // DATA_TYPE
-	}
-
 	/**
 	 * Create a null dataset
 	 */
@@ -378,7 +373,7 @@ public class CompoundIntegerDataset extends AbstractCompoundDataset {
 			logger.error("Need a single-element dataset");
 			throw new IllegalArgumentException("Need a single-element dataset");
 		}
-		if (a.getDType() != Dataset.INT32) { // DATA_TYPE
+		if (!IntegerDataset.class.isAssignableFrom(a.getClass())) { // CLASS_TYPE
 			logger.error("Dataset type must be int"); // PRIM_TYPE
 			throw new IllegalArgumentException("Dataset type must be int"); // PRIM_TYPE
 		}

--- a/org.eclipse.january/src/org/eclipse/january/dataset/CompoundLongDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/CompoundLongDataset.java
@@ -17,6 +17,8 @@ package org.eclipse.january.dataset;
 import java.util.Arrays;
 
 import org.apache.commons.math3.complex.Complex;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Extend compound dataset for long values // PRIM_TYPE
@@ -24,6 +26,8 @@ import org.apache.commons.math3.complex.Complex;
 public class CompoundLongDataset extends AbstractCompoundDataset {
 	// pin UID to base class
 	private static final long serialVersionUID = Dataset.serialVersionUID;
+
+	private static final Logger logger = LoggerFactory.getLogger(CompoundLongDataset.class);
 
 	protected long[] data; // subclass alias // PRIM_TYPE
 

--- a/org.eclipse.january/src/org/eclipse/january/dataset/CompoundLongDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/CompoundLongDataset.java
@@ -46,11 +46,6 @@ public class CompoundLongDataset extends AbstractCompoundDataset {
 		return array;
 	}
 
-	@Override
-	public int getDType() {
-		return Dataset.ARRAYINT64; // DATA_TYPE
-	}
-
 	/**
 	 * Create a null dataset
 	 */
@@ -378,7 +373,7 @@ public class CompoundLongDataset extends AbstractCompoundDataset {
 			logger.error("Need a single-element dataset");
 			throw new IllegalArgumentException("Need a single-element dataset");
 		}
-		if (a.getDType() != Dataset.INT64) { // DATA_TYPE
+		if (!LongDataset.class.isAssignableFrom(a.getClass())) { // CLASS_TYPE
 			logger.error("Dataset type must be long"); // PRIM_TYPE
 			throw new IllegalArgumentException("Dataset type must be long"); // PRIM_TYPE
 		}

--- a/org.eclipse.january/src/org/eclipse/january/dataset/CompoundShortDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/CompoundShortDataset.java
@@ -46,11 +46,6 @@ public class CompoundShortDataset extends AbstractCompoundDataset {
 		return array;
 	}
 
-	@Override
-	public int getDType() {
-		return Dataset.ARRAYINT16; // DATA_TYPE
-	}
-
 	/**
 	 * Create a null dataset
 	 */
@@ -378,7 +373,7 @@ public class CompoundShortDataset extends AbstractCompoundDataset {
 			logger.error("Need a single-element dataset");
 			throw new IllegalArgumentException("Need a single-element dataset");
 		}
-		if (a.getDType() != Dataset.INT16) { // DATA_TYPE
+		if (!ShortDataset.class.isAssignableFrom(a.getClass())) { // CLASS_TYPE
 			logger.error("Dataset type must be short"); // PRIM_TYPE
 			throw new IllegalArgumentException("Dataset type must be short"); // PRIM_TYPE
 		}

--- a/org.eclipse.january/src/org/eclipse/january/dataset/CompoundShortDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/CompoundShortDataset.java
@@ -17,6 +17,8 @@ package org.eclipse.january.dataset;
 import java.util.Arrays;
 
 import org.apache.commons.math3.complex.Complex;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Extend compound dataset for short values // PRIM_TYPE
@@ -24,6 +26,8 @@ import org.apache.commons.math3.complex.Complex;
 public class CompoundShortDataset extends AbstractCompoundDataset {
 	// pin UID to base class
 	private static final long serialVersionUID = Dataset.serialVersionUID;
+
+	private static final Logger logger = LoggerFactory.getLogger(CompoundShortDataset.class);
 
 	protected short[] data; // subclass alias // PRIM_TYPE
 

--- a/org.eclipse.january/src/org/eclipse/january/dataset/ContiguousIteratorWithPosition.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/ContiguousIteratorWithPosition.java
@@ -45,10 +45,11 @@ public class ContiguousIteratorWithPosition extends IndexIterator {
 	 * @param isize number of elements in an item
 	 */
 	public ContiguousIteratorWithPosition(final int[] shape, final int length, final int isize) {
+		final int rank = shape == null ? 0 : shape.length;
 		this.shape = shape;
-		endrank = this.shape.length - 1;
+		endrank = rank - 1;
 		istep = isize;
-		if (shape.length == 0) {
+		if (rank == 0) {
 			pos = new int[0];
 		} else {
 			pos = new int[endrank + 1];
@@ -88,7 +89,7 @@ public class ContiguousIteratorWithPosition extends IndexIterator {
 
 	@Override
 	public void reset() {
-		if (shape.length > 0) {
+		if (shape != null && shape.length > 0) {
 			Arrays.fill(pos, 0);
 			pos[endrank] = -1;
 		}

--- a/org.eclipse.january/src/org/eclipse/january/dataset/DTypeUtils.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/DTypeUtils.java
@@ -22,7 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class DTypeUtils {
-	protected static final Logger logger = LoggerFactory.getLogger(DTypeUtils.class);
+	private static final Logger logger = LoggerFactory.getLogger(DTypeUtils.class);
 
 	private static Map<Class<? extends Dataset>, Integer> createInterfaceMap() {
 		Map<Class<? extends Dataset>, Integer> map = new LinkedHashMap<>();

--- a/org.eclipse.january/src/org/eclipse/january/dataset/DatasetFactory.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/DatasetFactory.java
@@ -12,7 +12,6 @@
 
 package org.eclipse.january.dataset;
 
-import java.math.BigInteger;
 import java.util.Date;
 import java.util.List;
 
@@ -190,9 +189,6 @@ public class DatasetFactory {
 				d.setShape(shape);
 			}
 			return d;
-		}
-		if (obj instanceof BigInteger) {
-			obj = ((BigInteger) obj).longValue();
 		}
 
 		final int dtype = DTypeUtils.getDTypeFromObject(obj);

--- a/org.eclipse.january/src/org/eclipse/january/dataset/DatasetFactory.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/DatasetFactory.java
@@ -20,27 +20,6 @@ public class DatasetFactory {
 	/**
 	 * Create dataset with items ranging from 0 up to given stop in steps of 1
 	 * @param stop stop value is <strong>not</strong> included
-	 * @return a new double dataset of given shape and type, filled with values determined by parameters
-	 */
-	public static DoubleDataset createRange(final double stop) {
-		return createRange(DoubleDataset.class, 0, stop, 1);
-	}
-
-	/**
-	 * Create dataset with items ranging from given start up to given stop in given steps
-	 * @param start
-	 * @param stop stop value is <strong>not</strong> included
-	 * @param step spacing between items
-	 * @return a new 1D dataset of given type, filled with values determined by parameters
-	 * @since 2.1
-	 */
-	public static DoubleDataset createRange(final double start, final double stop, final double step) {
-		return createRange(DoubleDataset.class, start, stop, step);
-	}
-
-	/**
-	 * Create dataset with items ranging from 0 up to given stop in steps of 1
-	 * @param stop stop value is <strong>not</strong> included
 	 * @param dtype
 	 * @return a new dataset of given shape and type, filled with values determined by parameters
 	 * 
@@ -65,31 +44,7 @@ public class DatasetFactory {
 	 */
 	@Deprecated
 	public static Dataset createRange(final double start, final double stop, final double step, final int dtype) {
-		if ((step > 0) != (start <= stop)) {
-			throw new IllegalArgumentException("Invalid parameters: start and stop must be in correct order for step");
-		}
-
-		switch (dtype) {
-		case Dataset.BOOL:
-			break;
-		case Dataset.INT8:
-			return ByteDataset.createRange(start, stop, step);
-		case Dataset.INT16:
-			return ShortDataset.createRange(start, stop, step);
-		case Dataset.INT32:
-			return IntegerDataset.createRange(start, stop, step);
-		case Dataset.INT64:
-			return LongDataset.createRange(start, stop, step);
-		case Dataset.FLOAT32:
-			return FloatDataset.createRange(start, stop, step);
-		case Dataset.FLOAT64:
-			return DoubleDataset.createRange(start, stop, step);
-		case Dataset.COMPLEX64:
-			return ComplexFloatDataset.createRange(start, stop, step);
-		case Dataset.COMPLEX128:
-			return ComplexDoubleDataset.createRange(start, stop, step);
-		}
-		throw new IllegalArgumentException("dtype not known");
+		return createRange(DTypeUtils.getInterface(dtype), start, stop, step);
 	}
 
 	/**
@@ -100,7 +55,7 @@ public class DatasetFactory {
 	 * @return a new dataset of given shape and type, filled with values determined by parameters
 	 * 
 	 * @deprecated Please use the class-based methods in DatasetFactory,
-	 *             such as {@link #createRange(Class, double, double, double)}
+	 *             such as {@link #createRange(int, Class, double)}
 	 */
 	@Deprecated
 	public static CompoundDataset createRange(final int itemSize, final double stop, final int dtype) {
@@ -117,98 +72,12 @@ public class DatasetFactory {
 	 * @return a new 1D dataset of given type, filled with values determined by parameters
 	 * 
 	 * @deprecated Please use the class-based methods in DatasetFactory,
-	 *             such as {@link #createRange(Class, double, double, double)}
+	 *             such as {@link #createRange(int, Class, double, double, double)}
 	 */
 	@Deprecated
 	public static CompoundDataset createRange(final int itemSize, final double start, final double stop, final double step, final int dtype) {
-		if (itemSize < 1) {
-			throw new IllegalArgumentException("Item size must be greater or equal to 1");
-		}
-		if ((step > 0) != (start <= stop)) {
-			throw new IllegalArgumentException("Invalid parameters: start and stop must be in correct order for step");
-		}
-
-		switch (dtype) {
-		case Dataset.BOOL:
-			break;
-		case Dataset.ARRAYINT8:
-		case Dataset.INT8:
-			return CompoundIntegerDataset.createRange(itemSize, start, stop, step);
-		case Dataset.ARRAYINT16:
-		case Dataset.INT16:
-			return CompoundShortDataset.createRange(itemSize, start, stop, step);
-		case Dataset.ARRAYINT32:
-		case Dataset.INT32:
-			return CompoundIntegerDataset.createRange(itemSize, start, stop, step);
-		case Dataset.ARRAYINT64:
-		case Dataset.INT64:
-			return CompoundLongDataset.createRange(itemSize, start, stop, step);
-		case Dataset.ARRAYFLOAT32:
-		case Dataset.FLOAT32:
-			return CompoundFloatDataset.createRange(itemSize, start, stop, step);
-		case Dataset.ARRAYFLOAT64:
-		case Dataset.FLOAT64:
-			return CompoundDoubleDataset.createRange(itemSize, start, stop, step);
-		case Dataset.COMPLEX64:
-			if (itemSize != 2) {
-				throw new IllegalArgumentException("Item size must be equal to 2");
-			}
-			return ComplexFloatDataset.createRange(start, stop, step);
-		case Dataset.COMPLEX128:
-			if (itemSize != 2) {
-				throw new IllegalArgumentException("Item size must be equal to 2");
-			}
-			return ComplexFloatDataset.createRange(start, stop, step);
-		}
-		throw new IllegalArgumentException("dtype not known");
-	}
-
-	/**
-	 * Create a dataset from object (automatically detect dataset type)
-	 *
-	 * @param obj
-	 *            can be Java list, array or Number
-	 * @return dataset
-	 */
-	public static Dataset createFromObject(Object obj) {
-		return createFromObject(obj, null);
-	}
-
-	/**
-	 * Create a dataset from object (automatically detect dataset type)
-	 * 
-	 * @param obj
-	 *            can be Java list, array or Number
-	 * @param shape can be null
-	 * @return dataset
-	 */
-	public static Dataset createFromObject(Object obj, int... shape) {
-		if (obj instanceof IDataset) {
-			Dataset d = DatasetUtils.convertToDataset((IDataset) obj);
-			if (shape != null) {
-				d.setShape(shape);
-			}
-			return d;
-		}
-
-		final int dtype = DTypeUtils.getDTypeFromObject(obj);
-		return createFromObject(dtype, obj, shape);
-	}
-
-	/**
-	 * Create a dataset from object (automatically detect dataset type)
-	 * @param isUnsigned
-	 *            if true, interpret integer values as unsigned by increasing element bit width if required
-	 * @param obj
-	 *            can be a Java list, array or Number
-	 * @return dataset
-	 */
-	public static Dataset createFromObject(boolean isUnsigned, final Object obj) {
-		Dataset a = createFromObject(obj);
-		if (isUnsigned) {
-			a = DatasetUtils.makeUnsigned(a, true);
-		}
-		return a;
+		Class<? extends CompoundDataset> clazz = InterfaceUtils.getCompoundInterface(DTypeUtils.getInterface(dtype));
+		return createRange(itemSize, clazz, start, stop, step);
 	}
 
 	/**
@@ -259,154 +128,7 @@ public class DatasetFactory {
 	 */
 	@Deprecated
 	public static Dataset createFromObject(final int itemSize, final int dtype, final Object obj, final int... shape) {
-		Dataset d = null;
-
-		if (obj instanceof IDataset) {
-			d = itemSize == 1 ? DatasetUtils.cast((IDataset) obj, dtype) :
-				DatasetUtils.cast((IDataset) obj, false, dtype, itemSize);
-		} else {
-			// primitive arrays
-			Class<? extends Object> ca = obj == null ? null : obj.getClass().getComponentType();
-			if (ca != null && (ca.isPrimitive() || ca.equals(String.class))) {
-				switch (dtype) {
-				case Dataset.COMPLEX64:
-					return new ComplexFloatDataset(DTypeUtils.toFloatArray(obj, DTypeUtils.getLength(obj)), shape);
-				case Dataset.COMPLEX128:
-					return new ComplexDoubleDataset(DTypeUtils.toDoubleArray(obj, DTypeUtils.getLength(obj)), shape);
-				default:
-					d = createFromPrimitiveArray(DTypeUtils.getDTypeFromClass(ca), obj);
-					if (!DTypeUtils.isDTypeElemental(dtype)) {
-						d = DatasetUtils.createCompoundDataset(d, dtype == Dataset.RGB ? 3 : itemSize);
-						if (dtype == Dataset.RGB && d.getSize() == 1) { // special case of allowing a zero-rank RGB dataset
-							d.setShape();
-						}
-					}
-					d = DatasetUtils.cast(d, dtype);
-				}
-			} else {
-				switch (dtype) {
-				case Dataset.BOOL:
-					d = BooleanDataset.createFromObject(obj);
-					break;
-				case Dataset.INT8:
-					d = ByteDataset.createFromObject(obj);
-					break;
-				case Dataset.INT16:
-					d = ShortDataset.createFromObject(obj);
-					break;
-				case Dataset.INT32:
-					d = IntegerDataset.createFromObject(obj);
-					break;
-				case Dataset.INT64:
-					d = LongDataset.createFromObject(obj);
-					break;
-				case Dataset.ARRAYINT8:
-					d = CompoundByteDataset.createFromObject(itemSize, obj);
-					break;
-				case Dataset.ARRAYINT16:
-					d = CompoundShortDataset.createFromObject(itemSize, obj);
-					break;
-				case Dataset.ARRAYINT32:
-					d = CompoundIntegerDataset.createFromObject(itemSize, obj);
-					break;
-				case Dataset.ARRAYINT64:
-					d = CompoundLongDataset.createFromObject(itemSize, obj);
-					break;
-				case Dataset.FLOAT32:
-					d = FloatDataset.createFromObject(obj);
-					break;
-				case Dataset.FLOAT64:
-					d = DoubleDataset.createFromObject(obj);
-					break;
-				case Dataset.ARRAYFLOAT32:
-					d = CompoundFloatDataset.createFromObject(itemSize, obj);
-					break;
-				case Dataset.ARRAYFLOAT64:
-					d = CompoundDoubleDataset.createFromObject(itemSize, obj);
-					break;
-				case Dataset.COMPLEX64:
-					d = ComplexFloatDataset.createFromObject(obj);
-					break;
-				case Dataset.COMPLEX128:
-					d = ComplexDoubleDataset.createFromObject(obj);
-					break;
-				case Dataset.DATE:
-					d = DateDatasetImpl.createFromObject(obj);
-					break;
-				case Dataset.STRING:
-					d = StringDataset.createFromObject(obj);
-					break;
-				case Dataset.OBJECT:
-					d = ObjectDataset.createFromObject(obj);
-					break;
-				case Dataset.RGB:
-					d = RGBDataset.createFromObject(obj);
-					break;
-				default:
-					throw new IllegalArgumentException("Dataset type is not known");
-				}
-			}
-		}
-
-		if (shape != null && !(shape.length == 0 && d.getSize() > 1)) { // allow zero-rank datasets
-			d.setShape(shape);
-		}
-		return d;
-	}
-
-	private static Dataset createFromPrimitiveArray(final int dtype, final Object array) {
-		switch (dtype) {
-		case Dataset.BOOL:
-			return new BooleanDataset((boolean []) array);
-		case Dataset.INT8:
-			return new ByteDataset((byte []) array);
-		case Dataset.INT16:
-			return new ShortDataset((short []) array);
-		case Dataset.INT32:
-			return new IntegerDataset((int []) array, null);
-		case Dataset.INT64:
-			return new LongDataset((long []) array);
-		case Dataset.FLOAT32:
-			return new FloatDataset((float []) array);
-		case Dataset.FLOAT64:
-			return new DoubleDataset((double []) array);
-		case Dataset.STRING:
-			return new StringDataset((String []) array);
-		case Dataset.DATE:
-			return new DateDatasetImpl((Date []) array);
-		default:
-			return null;
-		}
-	}
-
-	/**
-	 * Create dataset of appropriate type from list
-	 * 
-	 * @param objectList
-	 * @return dataset filled with values from list
-	 */
-	public static Dataset createFromList(List<?> objectList) {
-		if (objectList == null || objectList.size() == 0) {
-			throw new IllegalArgumentException("No list or zero-length list given");
-		}
-
-		Object obj = null;
-		for (Object o : objectList) {
-			if (o != null) {
-				obj = o;
-				break;
-			}
-		}
-		if (obj == null) {
-			return zeros(ObjectDataset.class, objectList.size());
-		}
-
-		Class<? extends Object> clazz = obj.getClass();
-		if (InterfaceUtils.isElementSupported(clazz)) {
-			return createFromList(InterfaceUtils.getInterface(obj), objectList);
-		}
-
-		return createFromObject(objectList);
+		return createFromObject(itemSize, DTypeUtils.getInterface(dtype), obj, shape);
 	}
 
 	/**
@@ -421,27 +143,7 @@ public class DatasetFactory {
 	 */	
 	@Deprecated
 	public static Dataset createFromList(final int dtype, List<?> objectList) {
-		int len = objectList.size();
-		Dataset result = zeros(new int[] { len }, dtype);
-
-		for (int i = 0; i < len; i++) {
-			result.setObjectAbs(i, objectList.get(i));
-		}
-		return result;
-	}
-
-	/**
-	 * Create compound dataset of given type from given parts
-	 *
-	 * @param objects
-	 * @return compound dataset
-	 */
-	public static CompoundDataset createCompoundDataset(Object... objects) {
-		Dataset[] datasets = new Dataset[objects.length];
-		for (int i = 0; i < objects.length; i++) {
-			datasets[i] = createFromObject(objects[i]);
-		}
-		return DatasetUtils.createCompoundDataset(datasets);
+		return createFromList(DTypeUtils.getInterface(dtype), objectList);
 	}
 
 	/**
@@ -456,11 +158,7 @@ public class DatasetFactory {
 	 */
 	@Deprecated
 	public static CompoundDataset createCompoundDataset(final int dtype, Object... objects) {
-		Dataset[] datasets = new Dataset[objects.length];
-		for (int i = 0; i < objects.length; i++) {
-			datasets[i] = createFromObject(objects[i]);
-		}
-		return DatasetUtils.createCompoundDataset(dtype, datasets);
+		return (CompoundDataset) createCompoundDataset(DTypeUtils.getInterface(dtype), objects);
 	}
 
 	/**
@@ -476,22 +174,7 @@ public class DatasetFactory {
 	 */
 	@Deprecated
 	public static CompoundDataset createComplexDataset(final int dtype, Object real, Object imag) {
-		switch (dtype) {
-		case Dataset.COMPLEX64:
-			return new ComplexFloatDataset(createFromObject(real), createFromObject(imag));
-		case Dataset.COMPLEX128:
-			return new ComplexDoubleDataset(createFromObject(real), createFromObject(imag));
-		default:
-			throw new IllegalArgumentException("Dataset class must be a complex one");
-		}
-	}
-
-	/**
-	 * @param shape
-	 * @return a new double dataset of given shape, filled with zeros
-	 */
-	public static DoubleDataset zeros(final int... shape) {
-		return zeros(DoubleDataset.class, shape);
+		return createComplexDataset(DTypeUtils.getInterface(dtype), real, imag);
 	}
 
 	/**
@@ -504,41 +187,7 @@ public class DatasetFactory {
 	 */
 	@Deprecated
 	public static Dataset zeros(final int[] shape, final int dtype) {
-		switch (dtype) {
-		case Dataset.BOOL:
-			return new BooleanDataset(shape);
-		case Dataset.INT8:
-		case Dataset.ARRAYINT8:
-			return new ByteDataset(shape);
-		case Dataset.INT16:
-		case Dataset.ARRAYINT16:
-			return new ShortDataset(shape);
-		case Dataset.RGB:
-			return new RGBDataset(shape);
-		case Dataset.INT32:
-		case Dataset.ARRAYINT32:
-			return new IntegerDataset(shape);
-		case Dataset.INT64:
-		case Dataset.ARRAYINT64:
-			return new LongDataset(shape);
-		case Dataset.FLOAT32:
-		case Dataset.ARRAYFLOAT32:
-			return new FloatDataset(shape);
-		case Dataset.FLOAT64:
-		case Dataset.ARRAYFLOAT64:
-			return new DoubleDataset(shape);
-		case Dataset.COMPLEX64:
-			return new ComplexFloatDataset(shape);
-		case Dataset.COMPLEX128:
-			return new ComplexDoubleDataset(shape);
-		case Dataset.STRING:
-			return new StringDataset(shape);
-		case Dataset.DATE:
-			return new DateDatasetImpl(shape);
-		case Dataset.OBJECT:
-			return new ObjectDataset(shape);
-		}
-		throw new IllegalArgumentException("dtype not known or unsupported");
+		return zeros(DTypeUtils.getInterface(dtype), shape);
 	}
 
 	/**
@@ -571,53 +220,7 @@ public class DatasetFactory {
 	 */
 	@Deprecated
 	public static CompoundDataset compoundZeros(final int itemSize, final int[] shape, final int dtype) {
-		switch (dtype) {
-		case Dataset.INT8:
-		case Dataset.ARRAYINT8:
-			return new CompoundByteDataset(itemSize, shape);
-		case Dataset.INT16:
-		case Dataset.ARRAYINT16:
-			return new CompoundShortDataset(itemSize, shape);
-		case Dataset.RGB:
-			if (itemSize != 3) {
-				throw new IllegalArgumentException("Number of elements not compatible with RGB type");
-			}
-			return new RGBDataset(shape);
-		case Dataset.INT32:
-		case Dataset.ARRAYINT32:
-			return new CompoundIntegerDataset(itemSize, shape);
-		case Dataset.INT64:
-		case Dataset.ARRAYINT64:
-			return new CompoundLongDataset(itemSize, shape);
-		case Dataset.FLOAT32:
-		case Dataset.ARRAYFLOAT32:
-			return new CompoundFloatDataset(itemSize, shape);
-		case Dataset.FLOAT64:
-		case Dataset.ARRAYFLOAT64:
-			return new CompoundDoubleDataset(itemSize, shape);
-		case Dataset.COMPLEX64:
-			if (itemSize != 2) {
-				throw new IllegalArgumentException("Number of elements not compatible with complex type");
-			}
-			return new ComplexFloatDataset(shape);
-		case Dataset.COMPLEX128:
-			if (itemSize != 2) {
-				throw new IllegalArgumentException("Number of elements not compatible with complex type");
-			}
-			return new ComplexDoubleDataset(shape);
-		}
-		throw new IllegalArgumentException("dtype not a known compound type");
-	}
-
-	/**
-	 * @param dataset
-	 * @return a new dataset of same shape and class as input dataset, filled with zeros
-	 */
-	@SuppressWarnings("unchecked")
-	public static <T extends Dataset> T zeros(final T dataset) {
-		int dtype = dataset.getDType();
-		return (T) (DTypeUtils.isDTypeElemental(dtype) ? zeros(dataset, dtype) :
-			compoundZeros(dataset.getElementsPerItem(),  dataset.getShapeRef(), dtype));
+		return compoundZeros(itemSize, InterfaceUtils.getCompoundInterface(DTypeUtils.getInterface(dtype)), shape);
 	}
 
 	/**
@@ -632,19 +235,10 @@ public class DatasetFactory {
 	 */
 	@Deprecated
 	public static Dataset zeros(final Dataset dataset, final int dtype) {
-		final int[] shape = dataset.getShapeRef();
-		final int isize = DTypeUtils.isDTypeElemental(dtype) ? 1 :dataset.getElementsPerItem();
+		Class<? extends Dataset> clazz = DTypeUtils.getInterface(dtype);
+		final int isize = InterfaceUtils.isElemental(clazz) ? 1 :dataset.getElementsPerItem();
 
-		return zeros(isize, shape, dtype);
-	}
-
-	/**
-	 * @param dataset
-	 * @return a new dataset of same shape and class as input dataset, filled with ones
-	 */
-	@SuppressWarnings("unchecked")
-	public static <T extends Dataset> T ones(final T dataset) {
-		return (T) ones(dataset, dataset.getDType());
+		return zeros(isize, clazz, dataset.getShapeRef());
 	}
 
 	/**
@@ -659,18 +253,10 @@ public class DatasetFactory {
 	 */
 	@Deprecated
 	public static Dataset ones(final Dataset dataset, final int dtype) {
-		final int[] shape = dataset.getShapeRef();
-		final int isize = DTypeUtils.isDTypeElemental(dtype) ? 1 :dataset.getElementsPerItem();
+		Class<? extends Dataset> clazz = DTypeUtils.getInterface(dtype);
+		final int isize = InterfaceUtils.isElemental(clazz) ? 1 :dataset.getElementsPerItem();
 
-		return ones(isize, shape, dtype);
-	}
-
-	/**
-	 * @param shape
-	 * @return a new double dataset of given shape, filled with ones
-	 */
-	public static DoubleDataset ones(final int... shape) {
-		return ones(DoubleDataset.class, shape);
+		return ones(isize, clazz, dataset.getShapeRef());
 	}
 
 	/**
@@ -683,29 +269,7 @@ public class DatasetFactory {
 	 */
 	@Deprecated
 	public static Dataset ones(final int[] shape, final int dtype) {
-		switch (dtype) {
-		case Dataset.BOOL:
-			return BooleanDataset.ones(shape);
-		case Dataset.INT8:
-			return ByteDataset.ones(shape);
-		case Dataset.INT16:
-			return ShortDataset.ones(shape);
-		case Dataset.RGB:
-			return new RGBDataset(shape).fill(1);
-		case Dataset.INT32:
-			return IntegerDataset.ones(shape);
-		case Dataset.INT64:
-			return LongDataset.ones(shape);
-		case Dataset.FLOAT32:
-			return FloatDataset.ones(shape);
-		case Dataset.FLOAT64:
-			return DoubleDataset.ones(shape);
-		case Dataset.COMPLEX64:
-			return ComplexFloatDataset.ones(shape);
-		case Dataset.COMPLEX128:
-			return ComplexDoubleDataset.ones(shape);
-		}
-		throw new IllegalArgumentException("dtype not known");
+		return ones(DTypeUtils.getInterface(dtype), shape);
 	}
 
 	/**
@@ -720,45 +284,7 @@ public class DatasetFactory {
 	 */
 	@Deprecated
 	public static Dataset ones(final int itemSize, final int[] shape, final int dtype) {
-		if (itemSize == 1) {
-			return ones(shape, dtype);
-		}
-		switch (dtype) {
-		case Dataset.INT8:
-		case Dataset.ARRAYINT8:
-			return CompoundByteDataset.ones(itemSize, shape);
-		case Dataset.INT16:
-		case Dataset.ARRAYINT16:
-			return CompoundShortDataset.ones(itemSize, shape);
-		case Dataset.RGB:
-			if (itemSize != 3) {
-				throw new IllegalArgumentException("Number of elements not compatible with RGB type");
-			}
-			return new RGBDataset(shape).fill(1);
-		case Dataset.INT32:
-		case Dataset.ARRAYINT32:
-			return CompoundIntegerDataset.ones(itemSize, shape);
-		case Dataset.INT64:
-		case Dataset.ARRAYINT64:
-			return CompoundLongDataset.ones(itemSize, shape);
-		case Dataset.FLOAT32:
-		case Dataset.ARRAYFLOAT32:
-			return CompoundFloatDataset.ones(itemSize, shape);
-		case Dataset.FLOAT64:
-		case Dataset.ARRAYFLOAT64:
-			return CompoundDoubleDataset.ones(itemSize, shape);
-		case Dataset.COMPLEX64:
-			if (itemSize != 2) {
-				throw new IllegalArgumentException("Number of elements not compatible with complex type");
-			}
-			return ComplexFloatDataset.ones(shape);
-		case Dataset.COMPLEX128:
-			if (itemSize != 2) {
-				throw new IllegalArgumentException("Number of elements not compatible with complex type");
-			}
-			return ComplexDoubleDataset.ones(shape);
-		}
-		throw new IllegalArgumentException("dtype not a known compound type");
+		return ones(itemSize, DTypeUtils.getInterface(dtype), shape);
 	}
 
 	/**
@@ -776,6 +302,26 @@ public class DatasetFactory {
 	@Deprecated
 	public static Dataset createLinearSpace(final double start, final double stop, final int length, final int dtype) {
 		return createLinearSpace(DTypeUtils.getInterface(dtype), start, stop, length);
+	}
+
+	/**
+	 * Create a 1D dataset of logarithmically spaced values in closed interval. The base value is used to
+	 * determine the factor between values: factor = base ** step, where step is the interval between linearly
+	 * spaced sequence of points
+	 * 
+	 * @param start
+	 * @param stop stop value is included
+	 * @param length number of points
+	 * @param base
+	 * @param dtype
+	 * @return dataset with logarithmically spaced values
+	 * 
+	 * @deprecated Please use the class-based methods in DatasetFactory,
+	 *             such as {@link #createLogSpace(Class, double, double, int, double)}
+	 */
+	@Deprecated
+	public static Dataset createLogSpace(final double start, final double stop, final int length, final double base, final int dtype) {
+		return createLogSpace(DTypeUtils.getInterface(dtype), start, stop, length, base);
 	}
 
 	/**
@@ -802,29 +348,9 @@ public class DatasetFactory {
 				value = start + (num * i) / den;
 				ds.setObjectAbs(i, value);
 			}
-
+	
 			return ds;
 		}
-	}
-
-	/**
-	 * Create a 1D dataset of logarithmically spaced values in closed interval. The base value is used to
-	 * determine the factor between values: factor = base ** step, where step is the interval between linearly
-	 * spaced sequence of points
-	 * 
-	 * @param start
-	 * @param stop stop value is included
-	 * @param length number of points
-	 * @param base
-	 * @param dtype
-	 * @return dataset with logarithmically spaced values
-	 * 
-	 * @deprecated Please use the class-based methods in DatasetFactory,
-	 *             such as {@link #createLogSpace(Class, double, double, int, double)}
-	 */
-	@Deprecated
-	public static Dataset createLogSpace(final double start, final double stop, final int length, final double base, final int dtype) {
-		return createLogSpace(DTypeUtils.getInterface(dtype), start, stop, length, base);
 	}
 
 	/**
@@ -860,13 +386,33 @@ public class DatasetFactory {
 
 	/**
 	 * Create dataset with items ranging from 0 up to given stop in steps of 1
+	 * @param stop stop value is <strong>not</strong> included
+	 * @return a new double dataset of given shape and type, filled with values determined by parameters
+	 */
+	public static DoubleDataset createRange(final double stop) {
+		return createRange(DoubleDataset.class, 0, stop, 1);
+	}
+
+	/**
+	 * Create dataset with items ranging from given start up to given stop in given steps
+	 * @param start
+	 * @param stop stop value is <strong>not</strong> included
+	 * @param step spacing between items
+	 * @return a new 1D dataset of given type, filled with values determined by parameters
+	 * @since 2.1
+	 */
+	public static DoubleDataset createRange(final double start, final double stop, final double step) {
+		return createRange(DoubleDataset.class, start, stop, step);
+	}
+
+	/**
+	 * Create dataset with items ranging from 0 up to given stop in steps of 1
 	 * @param clazz dataset class
 	 * @param stop stop value is <strong>not</strong> included
 	 * @return a new dataset of given shape and class, filled with values determined by parameters
 	 */
-	@SuppressWarnings("unchecked")
 	public static <T extends Dataset> T createRange(Class<T> clazz, final double stop) {
-		return (T) createRange(0, stop, 1, DTypeUtils.getDType(clazz));
+		return createRange(clazz, 0, stop, 1);
 	}
 
 	/**
@@ -879,7 +425,32 @@ public class DatasetFactory {
 	 */
 	@SuppressWarnings("unchecked")
 	public static <T extends Dataset> T createRange(Class<T> clazz, final double start, final double stop, final double step) {
-		return (T) createRange(start, stop, step, DTypeUtils.getDType(clazz));
+		if ((step > 0) != (start <= stop)) {
+			throw new IllegalArgumentException("Invalid parameters: start and stop must be in correct order for step");
+		}
+
+		Dataset d = null;
+		if (ByteDataset.class.isAssignableFrom(clazz)) {
+			d = ByteDataset.createRange(start, stop, step);
+		} else if (ShortDataset.class.isAssignableFrom(clazz)) {
+			d = ShortDataset.createRange(start, stop, step);
+		} else if (IntegerDataset.class.isAssignableFrom(clazz)) {
+			d = IntegerDataset.createRange(start, stop, step);
+		} else if (LongDataset.class.isAssignableFrom(clazz)) {
+			d = LongDataset.createRange(start, stop, step);
+		} else if (FloatDataset.class.isAssignableFrom(clazz)) {
+			d = FloatDataset.createRange(start, stop, step);
+		} else if (DoubleDataset.class.isAssignableFrom(clazz)) {
+			d = DoubleDataset.createRange(start, stop, step);
+		} else if (ComplexFloatDataset.class.isAssignableFrom(clazz)) {
+			d = ComplexFloatDataset.createRange(start, stop, step);
+		} else if (ComplexDoubleDataset.class.isAssignableFrom(clazz)) {
+			d = ComplexDoubleDataset.createRange(start, stop, step);
+		} else {
+			throw new IllegalArgumentException("Dataset interface not supported");
+		}
+
+		return (T) d;
 	}
 
 	/**
@@ -890,9 +461,8 @@ public class DatasetFactory {
 	 * @return a new 1D dataset of given class, filled with values determined by parameters
 	 * @since 2.1
 	 */
-	@SuppressWarnings("unchecked")
 	public static <T extends CompoundDataset> T createRange(final int itemSize, Class<T> clazz, final double stop) {
-		return (T) createRange(itemSize, 0, stop, 1, DTypeUtils.getDType(clazz));
+		return createRange(itemSize, clazz, 0, stop, 1);
 	}
 
 	/**
@@ -907,7 +477,131 @@ public class DatasetFactory {
 	 */
 	@SuppressWarnings("unchecked")
 	public static <T extends CompoundDataset> T createRange(final int itemSize, Class<T> clazz, final double start, final double stop, final double step) {
-		return (T) createRange(itemSize, start, stop, step, DTypeUtils.getDType(clazz));
+		if (itemSize < 1) {
+			throw new IllegalArgumentException("Item size must be greater or equal to 1");
+		}
+		if ((step > 0) != (start <= stop)) {
+			throw new IllegalArgumentException("Invalid parameters: start and stop must be in correct order for step");
+		}
+
+		CompoundDataset c = null;
+		if (CompoundByteDataset.class.isAssignableFrom(clazz)) {
+			c = CompoundIntegerDataset.createRange(itemSize, start, stop, step);
+		} else if (CompoundShortDataset.class.isAssignableFrom(clazz)) {
+			c = CompoundShortDataset.createRange(itemSize, start, stop, step);
+		} else if (CompoundIntegerDataset.class.isAssignableFrom(clazz)) {
+			c = CompoundIntegerDataset.createRange(itemSize, start, stop, step);
+		} else if (CompoundLongDataset.class.isAssignableFrom(clazz)) {
+			c = CompoundLongDataset.createRange(itemSize, start, stop, step);
+		} else if (ComplexFloatDataset.class.isAssignableFrom(clazz)) {
+			if (itemSize != 2) {
+				throw new IllegalArgumentException("Item size must be equal to 2");
+			}
+			c = ComplexFloatDataset.createRange(start, stop, step);
+		} else if (ComplexDoubleDataset.class.isAssignableFrom(clazz)) {
+			if (itemSize != 2) {
+				throw new IllegalArgumentException("Item size must be equal to 2");
+			}
+			c = ComplexDoubleDataset.createRange(start, stop, step);
+		} else if (CompoundFloatDataset.class.isAssignableFrom(clazz)) {
+			c = CompoundFloatDataset.createRange(itemSize, start, stop, step);
+		} else if (CompoundDoubleDataset.class.isAssignableFrom(clazz)) {
+			c = CompoundDoubleDataset.createRange(itemSize, start, stop, step);
+		} else {
+			throw new IllegalArgumentException("dtype not known");
+		}
+		return (T) c;
+	}
+
+	/**
+	 * Create a dataset from object (automatically detect dataset type)
+	 *
+	 * @param obj
+	 *            can be Java list, array or Number
+	 * @return dataset
+	 */
+	public static Dataset createFromObject(Object obj) {
+		return createFromObject(obj, null);
+	}
+
+	/**
+	 * Create a dataset from object (automatically detect dataset type)
+	 * 
+	 * @param obj
+	 *            can be Java list, array or Number
+	 * @param shape can be null
+	 * @return dataset
+	 */
+	public static Dataset createFromObject(Object obj, int... shape) {
+		if (obj instanceof IDataset) {
+			Dataset d = DatasetUtils.convertToDataset((IDataset) obj);
+			if (shape != null) {
+				d.setShape(shape);
+			}
+			return d;
+		}
+	
+		return createFromObject(InterfaceUtils.getInterface(obj), obj, shape);
+	}
+
+	/**
+	 * Create a dataset from object (automatically detect dataset type)
+	 * @param isUnsigned
+	 *            if true, interpret integer values as unsigned by increasing element bit width if required
+	 * @param obj
+	 *            can be a Java list, array or Number
+	 * @return dataset
+	 */
+	public static Dataset createFromObject(boolean isUnsigned, final Object obj) {
+		Dataset a = createFromObject(obj);
+		if (isUnsigned) {
+			a = DatasetUtils.makeUnsigned(a, true);
+		}
+		return a;
+	}
+
+	/**
+	 * Create dataset of appropriate type from list
+	 * 
+	 * @param objectList
+	 * @return dataset filled with values from list
+	 */
+	public static Dataset createFromList(List<?> objectList) {
+		if (objectList == null || objectList.size() == 0) {
+			throw new IllegalArgumentException("No list or zero-length list given");
+		}
+	
+		Object obj = null;
+		for (Object o : objectList) {
+			if (o != null) {
+				obj = o;
+				break;
+			}
+		}
+		if (obj == null) {
+			return zeros(ObjectDataset.class, objectList.size());
+		}
+	
+		Class<? extends Object> clazz = obj.getClass();
+		if (InterfaceUtils.isElementSupported(clazz)) {
+			return createFromList(InterfaceUtils.getInterface(obj), objectList);
+		}
+	
+		return createFromObject(objectList);
+	}
+
+	/**
+	 * Create compound dataset of given type from given parts
+	 *
+	 * @param objects
+	 * @return compound dataset
+	 */
+	public static CompoundDataset createCompoundDataset(Object... objects) {
+		Dataset[] datasets = new Dataset[objects.length];
+		for (int i = 0; i < objects.length; i++) {
+			datasets[i] = createFromObject(objects[i]);
+		}
+		return DatasetUtils.createCompoundDataset(datasets);
 	}
 
 	/**
@@ -919,9 +613,8 @@ public class DatasetFactory {
 	 * @throws IllegalArgumentException if dataset class is not known
 	 * @since 2.1
 	 */
-	@SuppressWarnings("unchecked")
 	public static <T extends Dataset> T createFromObject(Class<T> clazz, Object obj) {
-		return (T) createFromObject(1, DTypeUtils.getDType(clazz), obj, null);
+		return createFromObject(1, clazz, obj, null);
 	}
 
 
@@ -933,9 +626,8 @@ public class DatasetFactory {
 	 * @param shape can be null
 	 * @return dataset
 	 */
-	@SuppressWarnings("unchecked")
 	public static <T extends Dataset> T createFromObject(Class<T> clazz, Object obj, int... shape) {
-		return (T) createFromObject(1, DTypeUtils.getDType(clazz), obj, shape);
+		return createFromObject(1, clazz, obj, shape);
 	}
 
 	/**
@@ -949,7 +641,108 @@ public class DatasetFactory {
 	 */
 	@SuppressWarnings("unchecked")
 	public static <T extends Dataset> T createFromObject(final int itemSize, Class<T> clazz, Object obj, int... shape) {
-		return (T) createFromObject(itemSize, DTypeUtils.getDType(clazz), obj, shape);
+		Dataset d = null;
+
+		if (obj instanceof IDataset) {
+			d = itemSize == 1 ? DatasetUtils.cast(clazz, (IDataset) obj) :
+				DatasetUtils.cast(itemSize, clazz, (IDataset) obj, false);
+		} else {
+			// primitive arrays
+			Class<? extends Object> ca = obj == null ? null : obj.getClass().getComponentType();
+			if (ca != null && (ca.isPrimitive() || ca.equals(String.class))) {
+				if (ComplexFloatDataset.class.isAssignableFrom(clazz)) {
+					return (T) new ComplexFloatDataset(DTypeUtils.toFloatArray(obj, DTypeUtils.getLength(obj)), shape);
+				} else if (ComplexDoubleDataset.class.isAssignableFrom(clazz)) {
+					return (T) new ComplexDoubleDataset(DTypeUtils.toDoubleArray(obj, DTypeUtils.getLength(obj)), shape);
+				} else {
+					d = createFromPrimitiveArray(InterfaceUtils.getInterfaceFromClass(1, ca), obj);
+					if (!InterfaceUtils.isElemental(clazz)) {
+						if (RGBDataset.class.isAssignableFrom(clazz)) {
+							d = DatasetUtils.createCompoundDataset(d, 3);
+							if (d.getSize() == 1) { // special case of allowing a zero-rank RGB dataset
+								d.setShape();
+							}
+						} else {
+							d = DatasetUtils.createCompoundDataset(d, itemSize);
+						}
+					}
+					d = d.cast(clazz);
+				}
+			} else {
+//				if (itemSize != 1 && !InterfaceUtils.isElemental(clazz)) {
+//					throw new IllegalArgumentException("Compound dataset interface needed for itemSize > 1");
+//				}
+				if (BooleanDataset.class.isAssignableFrom(clazz)) {
+					d = BooleanDataset.createFromObject(obj);
+				} else if (ByteDataset.class.isAssignableFrom(clazz)) {
+					d = ByteDataset.createFromObject(obj);
+				} else if (ShortDataset.class.isAssignableFrom(clazz)) {
+					d = ShortDataset.createFromObject(obj);
+				} else if (IntegerDataset.class.isAssignableFrom(clazz)) {
+					d = IntegerDataset.createFromObject(obj);
+				} else if (LongDataset.class.isAssignableFrom(clazz)) {
+					d = LongDataset.createFromObject(obj);
+				} else if (CompoundByteDataset.class.isAssignableFrom(clazz)) {
+					d = CompoundByteDataset.createFromObject(itemSize, obj);
+				} else if (RGBDataset.class.isAssignableFrom(clazz)) {
+					d = RGBDataset.createFromObject(obj);
+				} else if (CompoundShortDataset.class.isAssignableFrom(clazz)) {
+					d = CompoundShortDataset.createFromObject(itemSize, obj);
+				} else if (CompoundIntegerDataset.class.isAssignableFrom(clazz)) {
+					d = CompoundIntegerDataset.createFromObject(itemSize, obj);
+				} else if (CompoundLongDataset.class.isAssignableFrom(clazz)) {
+					d = CompoundLongDataset.createFromObject(itemSize, obj);
+				} else if (FloatDataset.class.isAssignableFrom(clazz)) {
+					d = FloatDataset.createFromObject(obj);
+				} else if (DoubleDataset.class.isAssignableFrom(clazz)) {
+					d = DoubleDataset.createFromObject(obj);
+				} else if (ComplexFloatDataset.class.isAssignableFrom(clazz)) {
+					d = ComplexFloatDataset.createFromObject(obj);
+				} else if (ComplexDoubleDataset.class.isAssignableFrom(clazz)) {
+					d = ComplexDoubleDataset.createFromObject(obj);
+				} else if (CompoundFloatDataset.class.isAssignableFrom(clazz)) {
+					d = CompoundFloatDataset.createFromObject(itemSize, obj);
+				} else if (CompoundDoubleDataset.class.isAssignableFrom(clazz)) {
+					d = CompoundDoubleDataset.createFromObject(itemSize, obj);
+				} else if (DateDataset.class.isAssignableFrom(clazz)) {
+					d = DateDatasetImpl.createFromObject(obj);
+				} else if (StringDataset.class.isAssignableFrom(clazz)) {
+					d = StringDataset.createFromObject(obj);
+				} else if (ObjectDataset.class.isAssignableFrom(clazz)) {
+					d = ObjectDataset.createFromObject(obj);
+				} else {
+					throw new IllegalArgumentException("Dataset interface is not unsupported");
+				}
+			}
+		}
+
+		if (shape != null && !(shape.length == 0 && d.getSize() > 1)) { // allow zero-rank datasets
+			d.setShape(shape);
+		}
+		return (T) d;
+	}
+
+	private static Dataset createFromPrimitiveArray(Class<? extends Dataset> clazz, final Object array) {
+		if (BooleanDataset.class.isAssignableFrom(clazz)) {
+			return new BooleanDataset((boolean[]) array);
+		} else if (ByteDataset.class.isAssignableFrom(clazz)) {
+			return new ByteDataset((byte[]) array);
+		} else if (ShortDataset.class.isAssignableFrom(clazz)) {
+			return new ShortDataset((short[]) array);
+		} else if (IntegerDataset.class.isAssignableFrom(clazz)) {
+			return new IntegerDataset((int[]) array, null);
+		} else if (LongDataset.class.isAssignableFrom(clazz)) {
+			return new LongDataset((long[]) array);
+		} else if (FloatDataset.class.isAssignableFrom(clazz)) {
+			return new FloatDataset((float[]) array);
+		} else if (DoubleDataset.class.isAssignableFrom(clazz)) {
+			return new DoubleDataset((double[]) array);
+		} else if (StringDataset.class.isAssignableFrom(clazz)) {
+			return new StringDataset((String[]) array);
+		} else if (DateDataset.class.isAssignableFrom(clazz)) {
+			return new DateDatasetImpl((Date[]) array);
+		}
+		return null;
 	}
 
 	/**
@@ -959,9 +752,14 @@ public class DatasetFactory {
 	 * @param objectList
 	 * @return dataset filled with values from list
 	 */
-	@SuppressWarnings("unchecked")
 	public static <T extends Dataset> T createFromList(Class<T> clazz, List<?> objectList) {
-		return (T) createFromList(DTypeUtils.getDType(clazz), objectList);
+		int len = objectList.size();
+		T result = zeros(clazz, len);
+
+		for (int i = 0; i < len; i++) {
+			result.setObjectAbs(i, objectList.get(i));
+		}
+		return result;
 	}
 
 	/**
@@ -970,10 +768,14 @@ public class DatasetFactory {
 	 * @param clazz dataset class
 	 * @param objects
 	 * @return compound dataset
+	 * @since 2.3
 	 */
-	@SuppressWarnings("unchecked")
-	public static <T extends Dataset> T createCompoundDataset(Class<T> clazz, Object... objects) {
-		return (T) createCompoundDataset(DTypeUtils.getDType(clazz), objects);
+	public static <T extends CompoundDataset> T createCompoundDataset(Class<T> clazz, Object... objects) {
+		Dataset[] datasets = new Dataset[objects.length];
+		for (int i = 0; i < objects.length; i++) {
+			datasets[i] = createFromObject(objects[i]);
+		}
+		return DatasetUtils.createCompoundDataset(clazz, datasets);
 	}
 
 	/**
@@ -983,10 +785,46 @@ public class DatasetFactory {
 	 * @param real
 	 * @param imag
 	 * @return complex dataset
+	 * @since 2.3
 	 */
 	@SuppressWarnings("unchecked")
-	public static <T extends Dataset> T createComplexDataset(Class<T> clazz, Object real, Object imag) {
-		return (T) createComplexDataset(DTypeUtils.getDType(clazz), real, imag);
+	public static <T extends CompoundDataset> T createComplexDataset(Class<? extends Dataset> clazz, Object real, Object imag) {
+		if (ComplexFloatDataset.class.isAssignableFrom(clazz)) {
+			return (T) new ComplexFloatDataset(createFromObject(real), createFromObject(imag));
+		} else if (ComplexDoubleDataset.class.isAssignableFrom(clazz)) {
+			return (T) new ComplexDoubleDataset(createFromObject(real), createFromObject(imag));
+		} else {
+			throw new IllegalArgumentException("Dataset class must be a complex one");
+		}
+	}
+
+	/**
+	 * @param shape
+	 * @return a new double dataset of given shape, filled with zeros
+	 */
+	public static DoubleDataset zeros(final int... shape) {
+		return zeros(DoubleDataset.class, shape);
+	}
+
+	/**
+	 * @param dataset
+	 * @return a new dataset of same shape and class as input dataset, filled with zeros
+	 */
+	public static <T extends Dataset> T zeros(final T dataset) {
+		return zeros(dataset, dataset.getShapeRef());
+	}
+
+	/**
+	 * @param dataset
+	 * @param shape
+	 * @return a new dataset of same class as input dataset and given shape, filled with zeros
+	 * @since 2.3
+	 */
+	@SuppressWarnings("unchecked")
+	public static <T extends Dataset> T zeros(final T dataset, int... shape) {
+		Class<? extends Dataset> clazz = dataset.getClass();
+		return (T) (InterfaceUtils.isElemental(dataset.getClass()) ? zeros(clazz, shape) :
+			compoundZeros(dataset.getElementsPerItem(), InterfaceUtils.getCompoundInterface(clazz), shape));
 	}
 
 	/**
@@ -996,7 +834,35 @@ public class DatasetFactory {
 	 */
 	@SuppressWarnings("unchecked")
 	public static <T extends Dataset> T zeros(Class<T> clazz, int... shape) {
-		return (T) zeros(shape, DTypeUtils.getDType(clazz));
+		if (BooleanDataset.class.isAssignableFrom(clazz)) {
+			return (T) new BooleanDataset(shape);
+		} else if (ByteDataset.class.isAssignableFrom(clazz)) {
+			return (T) new ByteDataset(shape);
+		} else if (ShortDataset.class.isAssignableFrom(clazz)) {
+			return (T) new ShortDataset(shape);
+		} else if (IntegerDataset.class.isAssignableFrom(clazz)) {
+			return (T) new IntegerDataset(shape);
+		} else if (LongDataset.class.isAssignableFrom(clazz)) {
+			return (T) new LongDataset(shape);
+		} else if (FloatDataset.class.isAssignableFrom(clazz)) {
+			return (T) new FloatDataset(shape);
+		} else if (DoubleDataset.class.isAssignableFrom(clazz)) {
+			return (T) new DoubleDataset(shape);
+		} else if (RGBDataset.class.isAssignableFrom(clazz)) {
+			return (T) new RGBDataset(shape);
+		} else if (ComplexFloatDataset.class.isAssignableFrom(clazz)) {
+			return (T) new ComplexFloatDataset(shape);
+		} else if (ComplexDoubleDataset.class.isAssignableFrom(clazz)) {
+			return (T) new ComplexDoubleDataset(shape);
+		} else if (StringDataset.class.isAssignableFrom(clazz)) {
+			return (T) new StringDataset(shape);
+		} else if (DateDataset.class.isAssignableFrom(clazz)) {
+			return (T) new DateDatasetImpl(shape);
+		} else if (ObjectDataset.class.isAssignableFrom(clazz)) {
+			return (T) new ObjectDataset(shape);
+		}
+
+		throw new IllegalArgumentException("Interface not known or unsupported");
 	}
 
 	/**
@@ -1008,7 +874,10 @@ public class DatasetFactory {
 	 */
 	@SuppressWarnings("unchecked")
 	public static <T extends Dataset> T zeros(int itemSize, Class<T> clazz, int... shape) {
-		return (T) zeros(itemSize, shape, DTypeUtils.getDType(clazz));
+		if (itemSize == 1 && InterfaceUtils.isElemental(clazz)) {
+			return zeros(clazz, shape);
+		}
+		return (T) compoundZeros(itemSize, InterfaceUtils.getCompoundInterface(clazz), shape);
 	}
 
 	/**
@@ -1016,9 +885,8 @@ public class DatasetFactory {
 	 * @param clazz dataset class
 	 * @return a new dataset of given class with same shape as input dataset, filled with zeros
 	 */
-	@SuppressWarnings("unchecked")
 	public static <T extends Dataset> T zeros(Dataset dataset, Class<T> clazz) {
-		return (T) zeros(dataset, DTypeUtils.getDType(clazz));
+		return (T) zeros(dataset.getElementsPerItem(), clazz, dataset.getShapeRef());
 	}
 
 	/**
@@ -1030,7 +898,52 @@ public class DatasetFactory {
 	 */
 	@SuppressWarnings("unchecked")
 	public static <T extends CompoundDataset> T compoundZeros(int itemSize, Class<T> clazz, int... shape) {
-		return (T) compoundZeros(itemSize, shape, DTypeUtils.getDType(clazz));
+		if (CompoundByteDataset.class.isAssignableFrom(clazz)) {
+			return (T) new CompoundByteDataset(itemSize, shape);
+		} else if (RGBDataset.class.isAssignableFrom(clazz)) {
+			if (itemSize != 3) {
+				throw new IllegalArgumentException("Number of elements not compatible with RGB type");
+			}
+			return (T) new RGBDataset(shape);
+		} else if (CompoundShortDataset.class.isAssignableFrom(clazz)) {
+			return (T) new CompoundShortDataset(itemSize, shape);
+		} else if (CompoundIntegerDataset.class.isAssignableFrom(clazz)) {
+			return (T) new CompoundIntegerDataset(itemSize, shape);
+		} else if (CompoundLongDataset.class.isAssignableFrom(clazz)) {
+			return (T) new CompoundLongDataset(itemSize, shape);
+		} else if (ComplexFloatDataset.class.isAssignableFrom(clazz)) {
+			if (itemSize != 2) {
+				throw new IllegalArgumentException("Number of elements not compatible with complex type");
+			}
+			return (T) new ComplexFloatDataset(shape);
+		} else if (CompoundFloatDataset.class.isAssignableFrom(clazz)) {
+			return (T) new CompoundFloatDataset(itemSize, shape);
+		} else if (ComplexDoubleDataset.class.isAssignableFrom(clazz)) {
+			if (itemSize != 2) {
+				throw new IllegalArgumentException("Number of elements not compatible with complex type");
+			}
+			return (T) new ComplexDoubleDataset(shape);
+		} else if (CompoundDoubleDataset.class.isAssignableFrom(clazz)) {
+			return (T) new CompoundDoubleDataset(itemSize, shape);
+		}
+		throw new IllegalArgumentException("Class not a known compound interface");
+	}
+
+	/**
+	 * @param shape
+	 * @return a new double dataset of given shape, filled with ones
+	 */
+	public static DoubleDataset ones(final int... shape) {
+		return ones(DoubleDataset.class, shape);
+	}
+
+	/**
+	 * @param dataset
+	 * @return a new dataset of same shape and class as input dataset, filled with ones
+	 */
+	@SuppressWarnings("unchecked")
+	public static <T extends Dataset> T ones(final T dataset) {
+		return (T) ones(dataset, dataset.getClass());
 	}
 
 	/**
@@ -1040,19 +953,67 @@ public class DatasetFactory {
 	 */
 	@SuppressWarnings("unchecked")
 	public static <T extends Dataset> T ones(Class<T> clazz, int... shape) {
-		return (T) ones(shape, DTypeUtils.getDType(clazz));
+		if (BooleanDataset.class.isAssignableFrom(clazz)) {
+			return (T) BooleanDataset.ones(shape);
+		} else if (ByteDataset.class.isAssignableFrom(clazz)) {
+			return (T) ByteDataset.ones(shape);
+		} else if (ShortDataset.class.isAssignableFrom(clazz)) {
+			return (T) ShortDataset.ones(shape);
+		} else if (IntegerDataset.class.isAssignableFrom(clazz)) {
+			return (T) IntegerDataset.ones(shape);
+		} else if (LongDataset.class.isAssignableFrom(clazz)) {
+			return (T) LongDataset.ones(shape);
+		} else if (FloatDataset.class.isAssignableFrom(clazz)) {
+			return (T) FloatDataset.ones(shape);
+		} else if (DoubleDataset.class.isAssignableFrom(clazz)) {
+			return (T) DoubleDataset.ones(shape);
+		} else if (RGBDataset.class.isAssignableFrom(clazz)) {
+			return (T) new RGBDataset(shape).fill(1);
+		} else if (ComplexFloatDataset.class.isAssignableFrom(clazz)) {
+			return (T) ComplexFloatDataset.ones(shape);
+		} else if (ComplexDoubleDataset.class.isAssignableFrom(clazz)) {
+			return (T) ComplexDoubleDataset.ones(shape);
+		} else if (StringDataset.class.isAssignableFrom(clazz)) {
+			return (T) StringDataset.ones(shape);
+		} else if (DateDataset.class.isAssignableFrom(clazz)) {
+			return (T) DateDatasetImpl.ones(shape);
+		} else if (ObjectDataset.class.isAssignableFrom(clazz)) {
+			return (T) ObjectDataset.ones(shape);
+		}
+		throw new IllegalArgumentException("Interface not known or unsupported");
 	}
 
 	/**
 	 * @param itemSize
-	 *            if equal to 1, then non-compound dataset is returned
 	 * @param clazz dataset class
 	 * @param shape
 	 * @return a new dataset of given item size, shape and class, filled with ones
 	 */
 	@SuppressWarnings("unchecked")
 	public static <T extends Dataset> T ones(int itemSize, Class<T> clazz, int... shape) {
-		return (T) ones(itemSize, shape, DTypeUtils.getDType(clazz));
+		if (InterfaceUtils.isElemental(clazz)) {
+			return ones(clazz, shape);
+		}
+
+		if (CompoundByteDataset.class.isAssignableFrom(clazz)) {
+			return (T) CompoundByteDataset.ones(itemSize, shape);
+		} else if (RGBDataset.class.isAssignableFrom(clazz)) {
+			if (itemSize != 3) {
+				throw new IllegalArgumentException("Number of elements not compatible with RGB type");
+			}
+			return (T) new RGBDataset(shape).fill(1);
+		} else if (CompoundShortDataset.class.isAssignableFrom(clazz)) {
+			return (T) CompoundShortDataset.ones(itemSize, shape);
+		} else if (CompoundIntegerDataset.class.isAssignableFrom(clazz)) {
+			return (T) CompoundIntegerDataset.ones(itemSize, shape);
+		} else if (CompoundLongDataset.class.isAssignableFrom(clazz)) {
+			return (T) CompoundLongDataset.ones(itemSize, shape);
+		} else if (CompoundFloatDataset.class.isAssignableFrom(clazz)) {
+			return (T) CompoundFloatDataset.ones(itemSize, shape);
+		} else if (CompoundDoubleDataset.class.isAssignableFrom(clazz)) {
+			return (T) CompoundDoubleDataset.ones(itemSize, shape);
+		}
+		throw new IllegalArgumentException("Class not a known compound interface");
 	}
 
 	/**
@@ -1060,8 +1021,7 @@ public class DatasetFactory {
 	 * @param clazz dataset class
 	 * @return a new dataset of given class with same shape as input dataset, filled with ones
 	 */
-	@SuppressWarnings("unchecked")
 	public static <T extends Dataset> T ones(Dataset dataset, Class<T> clazz) {
-		return (T) ones(dataset, DTypeUtils.getDType(clazz));
+		return (T) ones(dataset.getElementsPerItem(), clazz, dataset.getShapeRef());
 	}
 }

--- a/org.eclipse.january/src/org/eclipse/january/dataset/DatasetUtils.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/DatasetUtils.java
@@ -32,7 +32,7 @@ public class DatasetUtils {
 	/**
 	 * Setup the logging facilities
 	 */
-	transient protected static final Logger utilsLogger = LoggerFactory.getLogger(DatasetUtils.class);
+	private static final Logger utilsLogger = LoggerFactory.getLogger(DatasetUtils.class);
 
 	/**
 	 * Append copy of dataset with another dataset along n-th axis

--- a/org.eclipse.january/src/org/eclipse/january/dataset/DateDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/DateDataset.java
@@ -51,5 +51,4 @@ public interface DateDataset extends Dataset {
 	 * @return date
 	 */
 	public Date getDateAbs(final int index);
-	
 }

--- a/org.eclipse.january/src/org/eclipse/january/dataset/DateDatasetImpl.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/DateDatasetImpl.java
@@ -46,11 +46,6 @@ public class DateDatasetImpl extends StringDataset implements DateDataset {
 		super(datesToStrings(data), shape);
 	}
 
-	@Override
-	public int getDType() {
-		return DATE;
-	}
-
 	private static String[] datesToStrings(final Date[] dates) {
 		final String[] dateStrings = new String[dates.length];
 		for (int i = 0; i < dates.length; i++) {
@@ -138,7 +133,32 @@ public class DateDatasetImpl extends StringDataset implements DateDataset {
 		
 		return null;
 	}
-	
+
+	@Override
+	public Object getObject() {
+		return getDate();
+	}
+
+	@Override
+	public Object getObject(int i) {
+		return getDate(i);
+	}
+
+	@Override
+	public Object getObject(int i, int j) {
+		return getDate(i, j);
+	}
+
+	@Override
+	public Object getObject(int... pos) {
+		return getDate(pos);
+	}
+
+	@Override
+	public Object getObjectAbs(int index) {
+		return getDateAbs(index);
+	}
+
 	@Override
 	public void setItemDirect(final int dindex, final int sindex, final Object src) {
 		if (src instanceof String[]) {

--- a/org.eclipse.january/src/org/eclipse/january/dataset/DateDatasetImpl.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/DateDatasetImpl.java
@@ -13,9 +13,14 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class DateDatasetImpl extends StringDataset implements DateDataset {
 	// pin UID to base class
 	private static final long serialVersionUID = Dataset.serialVersionUID;
+
+	private static final Logger logger = LoggerFactory.getLogger(DateDatasetImpl.class);
 
 	private static final SimpleDateFormat ISO8601_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS");
 	

--- a/org.eclipse.january/src/org/eclipse/january/dataset/DoubleDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/DoubleDataset.java
@@ -52,11 +52,6 @@ public class DoubleDataset extends AbstractDataset {
 		return array;
 	}
 
-	@Override
-	public int getDType() {
-		return FLOAT64; // DATA_TYPE
-	}
-
 	/**
 	 * Create a null dataset
 	 */

--- a/org.eclipse.january/src/org/eclipse/january/dataset/DoubleDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/DoubleDataset.java
@@ -22,6 +22,8 @@ import java.util.TreeSet;
 
 import org.apache.commons.math3.complex.Complex; // NAN_OMIT
 import org.eclipse.january.metadata.StatisticsMetadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -30,6 +32,8 @@ import org.eclipse.january.metadata.StatisticsMetadata;
 public class DoubleDataset extends AbstractDataset {
 	// pin UID to base class
 	private static final long serialVersionUID = Dataset.serialVersionUID;
+
+	private static final Logger logger = LoggerFactory.getLogger(DoubleDataset.class);
 
 	protected double[] data; // subclass alias // PRIM_TYPE
 

--- a/org.eclipse.january/src/org/eclipse/january/dataset/FloatDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/FloatDataset.java
@@ -52,11 +52,6 @@ public class FloatDataset extends AbstractDataset {
 		return array;
 	}
 
-	@Override
-	public int getDType() {
-		return FLOAT32; // DATA_TYPE
-	}
-
 	/**
 	 * Create a null dataset
 	 */

--- a/org.eclipse.january/src/org/eclipse/january/dataset/FloatDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/FloatDataset.java
@@ -22,6 +22,8 @@ import java.util.TreeSet;
 
 import org.apache.commons.math3.complex.Complex;
 import org.eclipse.january.metadata.StatisticsMetadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -30,6 +32,8 @@ import org.eclipse.january.metadata.StatisticsMetadata;
 public class FloatDataset extends AbstractDataset {
 	// pin UID to base class
 	private static final long serialVersionUID = Dataset.serialVersionUID;
+
+	private static final Logger logger = LoggerFactory.getLogger(FloatDataset.class);
 
 	protected float[] data; // subclass alias // PRIM_TYPE
 

--- a/org.eclipse.january/src/org/eclipse/january/dataset/ILazyDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/ILazyDataset.java
@@ -27,7 +27,7 @@ import org.eclipse.january.metadata.MetadataType;
 public interface ILazyDataset extends Serializable, IMetadataProvider, INameable {
 		
 	/**
-	 * @return Boxed class of element
+	 * @return Boxed class of element. Can be null when interface is not defined
 	 */
 	public Class<?> getElementClass();
 

--- a/org.eclipse.january/src/org/eclipse/january/dataset/IntegerDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/IntegerDataset.java
@@ -52,11 +52,6 @@ public class IntegerDataset extends AbstractDataset {
 		return array;
 	}
 
-	@Override
-	public int getDType() {
-		return INT32; // DATA_TYPE
-	}
-
 	/**
 	 * Create a null dataset
 	 */

--- a/org.eclipse.january/src/org/eclipse/january/dataset/IntegerDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/IntegerDataset.java
@@ -22,6 +22,8 @@ import java.util.TreeSet;
 
 import org.apache.commons.math3.complex.Complex;
 import org.eclipse.january.metadata.StatisticsMetadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -30,6 +32,8 @@ import org.eclipse.january.metadata.StatisticsMetadata;
 public class IntegerDataset extends AbstractDataset {
 	// pin UID to base class
 	private static final long serialVersionUID = Dataset.serialVersionUID;
+
+	private static final Logger logger = LoggerFactory.getLogger(IntegerDataset.class);
 
 	protected int[] data; // subclass alias // PRIM_TYPE
 

--- a/org.eclipse.january/src/org/eclipse/january/dataset/IntegersIterator.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/IntegersIterator.java
@@ -55,8 +55,13 @@ public class IntegersIterator extends IndexIterator {
 	 * @param index an array of integer dataset, boolean dataset, slices or null entries (same as full slices)
 	 */
 	public IntegersIterator(final boolean restrict1D, final int[] shape, final Object... index) {
-		ishape = shape.clone();
-		irank = shape.length;
+		if (shape == null) {
+			ishape = null;
+			irank = 0;
+		}  else {
+			ishape = shape.clone();
+			irank = shape.length;
+		}
 		if (irank < index.length) {
 			throw new IllegalArgumentException("Number of index datasets is greater than rank of dataset");
 		}
@@ -166,7 +171,7 @@ public class IntegersIterator extends IndexIterator {
 			}
 		}
 		orank = oShape.size();
-		oshape = new int[orank];
+		oshape = orank == 0 && ishape == null ? null : new int[orank];
 		for (int i = 0; i < orank; i++) {
 			oshape[i] = oShape.get(i);
 		}

--- a/org.eclipse.january/src/org/eclipse/january/dataset/InterfaceUtils.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/InterfaceUtils.java
@@ -476,6 +476,30 @@ public class InterfaceUtils {
 	 * Convert double to number
 	 * @param clazz dataset interface
 	 * @param x
+	 * @return number if integer. Return null if not interface is not numerical
+	 * @since 2.3
+	 */
+	public static Number fromDoubleToNumber(Class<? extends Dataset> clazz, double x) {
+		if (BooleanDataset.class.isAssignableFrom(clazz) || ByteDataset.class.isAssignableFrom(clazz)) {
+			return Byte.valueOf((byte) (long) x);
+		} else if (ShortDataset.class.isAssignableFrom(clazz)) {
+			return Short.valueOf((short) (long) x);
+		} else if (IntegerDataset.class.isAssignableFrom(clazz)) {
+			return Integer.valueOf((int) (long) x);
+		} else if (LongDataset.class.isAssignableFrom(clazz)) {
+			return Long.valueOf((long) x);
+		} else if (FloatDataset.class.isAssignableFrom(clazz)) {
+			return Float.valueOf((float) x);
+		} else if (DoubleDataset.class.isAssignableFrom(clazz)) {
+			return Double.valueOf(x);
+		}
+		return null;
+	}
+
+	/**
+	 * Convert double to number
+	 * @param clazz dataset interface
+	 * @param x
 	 * @return biggest number if integer. Return null if not interface is not numerical
 	 */
 	public static Number fromDoubleToBiggestNumber(Class<? extends Dataset> clazz, double x) {

--- a/org.eclipse.january/src/org/eclipse/january/dataset/InterfaceUtils.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/InterfaceUtils.java
@@ -395,20 +395,20 @@ public class InterfaceUtils {
 	public static Class<? extends Dataset> getLargestInterface(Dataset a) {
 		if (a instanceof BooleanDataset || a instanceof ByteDataset || a instanceof ShortDataset) {
 			return IntegerDataset.class;
-		} else if (a instanceof IntegerDataset || a instanceof LongDataset) {
+		} else if (a instanceof IntegerDataset) {
 			return LongDataset.class;
-		} else if (a instanceof FloatDataset || a instanceof DoubleDataset) {
+		} else if (a instanceof FloatDataset) {
 			return DoubleDataset.class;
-		} else if (a instanceof ComplexFloatDataset || a instanceof ComplexDoubleDataset) {
+		} else if (a instanceof ComplexFloatDataset) {
 			return ComplexDoubleDataset.class;
 		} else if (a instanceof CompoundByteDataset || a instanceof CompoundShortDataset) {
 			return CompoundIntegerDataset.class;
-		} else if (a instanceof CompoundIntegerDataset || a instanceof CompoundLongDataset) {
+		} else if (a instanceof CompoundIntegerDataset) {
 			return CompoundLongDataset.class;
-		} else if (a instanceof CompoundFloatDataset || a instanceof CompoundDoubleDataset) {
+		} else if (a instanceof CompoundFloatDataset) {
 			return CompoundDoubleDataset.class;
 		}
-		throw new IllegalArgumentException("Unsupported dataset type");
+		return a.getClass();
 	}
 
 	/**
@@ -488,6 +488,26 @@ public class InterfaceUtils {
 			return Float.valueOf((float) x);
 		} else if (DoubleDataset.class.isAssignableFrom(clazz)) {
 			return Double.valueOf(x);
+		}
+		return null;
+	}
+
+	/**
+	 * @param clazz dataset interface
+	 * @param x
+	 * @return biggest native primitive if integer
+	 * @since 2.3
+	 */
+	public static Number toBiggestNumber(Class<? extends Dataset> clazz, Number x) {
+		if (BooleanDataset.class.isAssignableFrom(clazz) || ByteDataset.class.isAssignableFrom(clazz)
+				|| ShortDataset.class.isAssignableFrom(clazz) || IntegerDataset.class.isAssignableFrom(clazz)) {
+			return x instanceof Integer ? x : Integer.valueOf(x.intValue());
+		} else if (LongDataset.class.isAssignableFrom(clazz)) {
+			return x instanceof Long ? x : Long.valueOf(x.longValue());
+		} else if (FloatDataset.class.isAssignableFrom(clazz)) {
+			return x instanceof Float ? x : Float.valueOf(x.floatValue());
+		} else if (DoubleDataset.class.isAssignableFrom(clazz)) {
+			return x instanceof Double ? x : Double.valueOf(x.doubleValue());
 		}
 		return null;
 	}

--- a/org.eclipse.january/src/org/eclipse/january/dataset/InterfaceUtils.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/InterfaceUtils.java
@@ -16,6 +16,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 
 import org.apache.commons.math3.complex.Complex;
 
@@ -34,10 +35,14 @@ public class InterfaceUtils {
 	private static final Map<Class<? extends Dataset>, Class<? extends CompoundDataset>> interface2Compound;
 
 	private static final Map<Class<? extends CompoundDataset>, Class<? extends Dataset>> compound2Interface;
+
+	private static Set<Class<? extends Dataset>> interfaces;
+
 	static {
 		class2Interface = createClassInterfaceMap();
 
 		interface2Class = createInterfaceClassMap();
+		interfaces = interface2Class.keySet();
 
 		elementBytes = createElementBytesMap();
 
@@ -48,6 +53,9 @@ public class InterfaceUtils {
 		for (Entry<Class<? extends Dataset>, Class<? extends CompoundDataset>> e : interface2Compound.entrySet()) {
 			compound2Interface.put(e.getValue(), e.getKey());
 		}
+		compound2Interface.put(RGBDataset.class, ShortDataset.class);
+		compound2Interface.put(ComplexFloatDataset.class, FloatDataset.class);
+		compound2Interface.put(ComplexDoubleDataset.class, DoubleDataset.class);
 	}
 
 	private static Map<Class<?>, Class<? extends Dataset>> createClassInterfaceMap() {
@@ -73,25 +81,27 @@ public class InterfaceUtils {
 	}
 
 	private static Map<Class<? extends Dataset>, Class<?>> createInterfaceClassMap() {
-		Map<Class<? extends Dataset>, Class<?>> result = new HashMap<>();
+		Map<Class<? extends Dataset>, Class<?>> result = new LinkedHashMap<>();
+		// ordering is likelihood of occurrence as it is used in an iterative check
+		// XXX for current implementation
+		result.put(DoubleDataset.class, Double.class);
+		result.put(DateDataset.class, Date.class); // XXX must be before string (and integer for unit test)
+		result.put(IntegerDataset.class, Integer.class);
 		result.put(BooleanDataset.class, Boolean.class);
+		result.put(StringDataset.class, String.class);
+		result.put(ComplexDoubleDataset.class, Double.class); // XXX must be before compound double
+		result.put(RGBDataset.class, Short.class); // XXX must be before compound short
 		result.put(ByteDataset.class, Byte.class);
 		result.put(ShortDataset.class, Short.class);
-		result.put(IntegerDataset.class, Integer.class);
 		result.put(LongDataset.class, Long.class);
 		result.put(FloatDataset.class, Float.class);
-		result.put(DoubleDataset.class, Double.class);
-		result.put(CompoundByteDataset.class, Byte.class);
+		result.put(ComplexFloatDataset.class, Float.class); // XXX must be before compound float
 		result.put(CompoundShortDataset.class, Short.class);
+		result.put(CompoundByteDataset.class, Byte.class);
 		result.put(CompoundIntegerDataset.class, Integer.class);
 		result.put(CompoundLongDataset.class, Long.class);
 		result.put(CompoundFloatDataset.class, Float.class);
 		result.put(CompoundDoubleDataset.class, Double.class);
-		result.put(ComplexFloatDataset.class, Float.class);
-		result.put(ComplexDoubleDataset.class, Double.class);
-		result.put(RGBDataset.class, Short.class);
-		result.put(StringDataset.class, String.class);
-		result.put(DateDataset.class, Date.class);
 		result.put(ObjectDataset.class, Object.class);
 		return result;
 	}
@@ -135,6 +145,39 @@ public class InterfaceUtils {
 	}
 
 	/**
+	 * @param object
+	 * @param dInterface dataset interface
+	 * @return true if object is an instance of dataset interface
+	 */
+	public static boolean isInstance(Object object, final Class<? extends Dataset> dInterface) {
+		return dInterface.isInstance(object);
+	}
+
+	/**
+	 * @param clazz
+	 * @param dInterface dataset interface
+	 * @return true if given class implements interface
+	 */
+	public static boolean hasInterface(final Class<? extends Dataset> clazz, final Class<? extends Dataset> dInterface) {
+		return dInterface.isAssignableFrom(clazz);
+	}
+
+	/**
+	 * @param clazz
+	 * @param dInterfaces dataset interface
+	 * @return true if given class implements any of the interfaces
+	 */
+	@SuppressWarnings("unchecked")
+	public static boolean hasInterface(final Class<? extends Dataset> clazz, final Class<? extends Dataset>... dInterfaces) {
+		for (Class<? extends Dataset> d : dInterfaces) {
+			if (d != null && d.isAssignableFrom(clazz)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
 	 * @param clazz
 	 * @return true if supported as an element class (note, Object is not supported)
 	 */
@@ -152,7 +195,7 @@ public class InterfaceUtils {
 
 	/**
 	 * Get dataset interface from an object. The following are supported: Java Number objects, Apache common math Complex
-	 * objects, Java arrays and lists
+	 * objects, Java arrays and lists, Dataset objects and ILazyDataset object
 	 *
 	 * @param obj
 	 * @return dataset interface 
@@ -168,10 +211,7 @@ public class InterfaceUtils {
 			List<?> jl = (List<?>) obj;
 			int l = jl.size();
 			for (int i = 0; i < l; i++) {
-				Class<? extends Dataset> lc = getInterface(jl.get(i));
-				if (isBetter(lc, dc)) {
-					dc = lc;
-				}
+				dc = getBestInterface(dc, getInterface(jl.get(i)));
 			}
 		} else if (obj.getClass().isArray()) {
 			Class<?> ca = obj.getClass().getComponentType();
@@ -181,13 +221,10 @@ public class InterfaceUtils {
 			int l = Array.getLength(obj);
 			for (int i = 0; i < l; i++) {
 				Object lo = Array.get(obj, i);
-				Class<? extends Dataset> lc = getInterface(lo);
-				if (isBetter(lc, dc)) {
-					dc = lc;
-				}
+				dc = getBestInterface(dc, getInterface(lo));
 			}
 		} else if (obj instanceof Dataset) {
-			return ((Dataset) obj).getClass();
+			dc = findSubInterface(((Dataset) obj).getClass());
 		} else if (obj instanceof ILazyDataset) {
 			dc = getInterfaceFromClass(((ILazyDataset) obj).getElementsPerItem(), ((ILazyDataset) obj).getElementClass());
 		} else {
@@ -197,6 +234,34 @@ public class InterfaceUtils {
 			}
 		}
 		return dc;
+	}
+
+	/**
+	 * Find sub-interface of Dataset
+	 * @param clazz
+	 * @return sub-interface or null if given class is Dataset.class
+	 * @since 2.3
+	 */
+	public static Class<? extends Dataset> findSubInterface(Class<? extends Dataset> clazz) {
+		if (Dataset.class.equals(clazz)) {
+			throw new IllegalArgumentException("Class must be a sub-interface of Dataset");
+		}
+		for (Class<? extends Dataset> i : interfaces) {
+			if (i.isAssignableFrom(clazz)) {
+				return i;
+			}
+		}
+		// XXX special cases for current implementation
+		if (BooleanDatasetBase.class.equals(clazz)) {
+			return BooleanDataset.class;
+		}
+		if (StringDatasetBase.class.equals(clazz)) {
+			return StringDataset.class;
+		}
+		if (ObjectDatasetBase.class.equals(clazz)) {
+			return ObjectDataset.class;
+		}
+		throw new IllegalArgumentException("Unknown sub-interface of Dataset");
 	}
 
 	/**
@@ -220,7 +285,27 @@ public class InterfaceUtils {
 	 * @return elemental dataset interface available for given dataset interface
 	 */
 	public static Class<? extends Dataset> getElementalInterface(final Class<? extends Dataset> clazz) {
-		return isElemental(clazz) ? clazz : compound2Interface.get(clazz);
+		Class<? extends Dataset> c = findSubInterface(clazz);
+		return isElemental(c) ? c : compound2Interface.get(c);
+	}
+
+	/**
+	 * @param clazz dataset interface
+	 * @return compound dataset interface available for given dataset interface
+	 */
+	@SuppressWarnings("unchecked")
+	public static Class<? extends CompoundDataset> getCompoundInterface(final Class<? extends Dataset> clazz) {
+		Class<? extends CompoundDataset> c = null; 
+		Class<? extends Dataset> d = findSubInterface(clazz);
+		if (isElemental(d)) {
+			c = interface2Compound.get(d);
+		} else {
+			c = (Class<? extends CompoundDataset>) d;
+		}
+		if (c == null) {
+			throw new IllegalArgumentException("Interface cannot be compound");
+		}
+		return c;
 	}
 
 	/**
@@ -236,7 +321,7 @@ public class InterfaceUtils {
 	 * @return true if dataset interface is not compound or complex
 	 */
 	public static boolean isElemental(Class<? extends Dataset> clazz) {
-		return !CompoundDataset.class.isAssignableFrom(clazz) || !ComplexFloatDataset.class.equals(clazz) || !ComplexDoubleDataset.class.equals(clazz);
+		return !CompoundDataset.class.isAssignableFrom(clazz);
 	}
 
 	/**
@@ -244,7 +329,8 @@ public class InterfaceUtils {
 	 * @return true if dataset interface is compound (not complex)
 	 */
 	public static boolean isCompound(Class<? extends Dataset> clazz) {
-		return compound2Interface.containsKey(clazz) || RGBDataset.class.equals(clazz);
+		Class<? extends Dataset> c = findSubInterface(clazz);
+		return compound2Interface.containsKey(c);
 	}
 
 	/**
@@ -332,19 +418,21 @@ public class InterfaceUtils {
 	 * @return best dataset interface
 	 */
 	public static Class<? extends Dataset> getBestInterface(Class<? extends Dataset> a, Class<? extends Dataset> b) {
-		boolean isElemental = true;
-		
 		if (a == null) {
 			return b;
 		}
 		if (b == null) {
 			return a;
 		}
-		if (!isElemental(a)) {
+
+		boolean isElemental = true;
+		final boolean az = isComplex(a);
+		if (!az && !isElemental(a)) {
 			isElemental = false;
 			a = compound2Interface.get(a);
 		}
-		if (!isElemental(b)) {
+		final boolean bz = isComplex(b);
+		if (!bz && !isElemental(b)) {
 			isElemental = false;
 			b = compound2Interface.get(b);
 		}
@@ -352,20 +440,21 @@ public class InterfaceUtils {
 		if (isFloating(a)) {
 			if (!isFloating(b)) {
 				b = getBestFloatInterface(b); // note doesn't change if not numerical!!!
-			} else if (isComplex(b)) {
-				a = DoubleDataset.class.isAssignableFrom(a) ? ComplexDoubleDataset.class : ComplexFloatDataset.class;
 			}
-			if (isComplex(a) && !isComplex(b)) {
+			if (az) {
 				b = DoubleDataset.class.isAssignableFrom(b) ? ComplexDoubleDataset.class : ComplexFloatDataset.class;
 			}
 		} else if (isFloating(b)) {
 			a = getBestFloatInterface(a);
-			if (isComplex(b)) {
+			if (bz) {
 				a = DoubleDataset.class.isAssignableFrom(a) ? ComplexDoubleDataset.class : ComplexFloatDataset.class;
 			}
 		}
 
 		Class<? extends Dataset> c = isBetter(interface2Class.get(a), interface2Class.get(b)) ? a : b;
+		if ((az || bz) && !isComplex(c)) {
+			c = DoubleDataset.class.isAssignableFrom(c) ? ComplexDoubleDataset.class : ComplexFloatDataset.class;
+		}
 
 		if (!isElemental && interface2Compound.containsKey(c)) {
 			c = interface2Compound.get(c);

--- a/org.eclipse.january/src/org/eclipse/january/dataset/LazyDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/LazyDataset.java
@@ -160,6 +160,11 @@ public class LazyDataset extends LazyDatasetBase implements Serializable, Clonea
 		}, dataset.getName(), dataset.getElementsPerItem(), dataset.getClass(), dataset.getShapeRef());
 	}
 
+	@Override
+	public Class<?> getElementClass() {
+		return InterfaceUtils.getElementClass(clazz);
+	}
+
 	/**
 	 * Can return -1 for unknown
 	 */
@@ -757,7 +762,7 @@ public class LazyDataset extends LazyDatasetBase implements Serializable, Clonea
 	 */
 	public static int getMaxSliceLength(ILazyDataset lazySet, int dimension) {
 		// size in bytes of each item
-		final double size = DTypeUtils.getItemBytes(DTypeUtils.getDTypeFromClass(lazySet.getElementClass()), lazySet.getElementsPerItem());
+		final double size = InterfaceUtils.getItemBytes(lazySet.getElementsPerItem(), InterfaceUtils.getInterface(lazySet));
 		
 		// Max in bytes takes into account our minimum requirement
 		final double max  = Math.max(Runtime.getRuntime().totalMemory(), Runtime.getRuntime().maxMemory());

--- a/org.eclipse.january/src/org/eclipse/january/dataset/LazyDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/LazyDataset.java
@@ -170,6 +170,7 @@ public class LazyDataset extends LazyDatasetBase implements Serializable, Clonea
 
 	/**
 	 * @return dataset interface that supports element class and number of elements
+	 * @since 2.3
 	 */
 	public Class<? extends Dataset> getInterface() {
 		return clazz;

--- a/org.eclipse.january/src/org/eclipse/january/dataset/LazyDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/LazyDataset.java
@@ -33,9 +33,13 @@ import org.eclipse.january.metadata.OriginMetadata;
 import org.eclipse.january.metadata.Reshapeable;
 import org.eclipse.january.metadata.Sliceable;
 import org.eclipse.january.metadata.Transposable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class LazyDataset extends LazyDatasetBase implements Serializable, Cloneable {
 	private static final long serialVersionUID = 2467865859867440242L;
+
+	private static final Logger logger = LoggerFactory.getLogger(LazyDataset.class);
 
 	protected Map<Class<? extends MetadataType>, List<MetadataType>> oMetadata = null;
 	protected int[] oShape; // original shape

--- a/org.eclipse.january/src/org/eclipse/january/dataset/LazyDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/LazyDataset.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.eclipse.january.DatasetException;
 import org.eclipse.january.IMonitor;
@@ -63,7 +64,7 @@ public class LazyDataset extends LazyDatasetBase implements Serializable, Clonea
 	 * @param loader
 	 * @param name
 	 * @param elements
-	 * @param clazz dataset interface
+	 * @param clazz dataset interface (can be null to represent undefined interface)
 	 * @param shape
 	 * @since 2.3
 	 */
@@ -85,7 +86,7 @@ public class LazyDataset extends LazyDatasetBase implements Serializable, Clonea
 	 * Create a lazy dataset
 	 * @param loader
 	 * @param name
-	 * @param clazz dataset interface
+	 * @param clazz dataset interface (can be null to represent undefined interface)
 	 * @param shape
 	 * @since 2.3
 	 */
@@ -166,15 +167,15 @@ public class LazyDataset extends LazyDatasetBase implements Serializable, Clonea
 	}
 
 	/**
-	 * Can return -1 for unknown
+	 * Can return -1 when dataset interface is not defined
 	 */
 	@Override
 	public int getDType() {
-		return DTypeUtils.getDType(clazz);
+		return clazz == null ? -1 : DTypeUtils.getDType(clazz);
 	}
 
 	/**
-	 * @return dataset interface that supports element class and number of elements
+	 * @return dataset interface that supports element class and number of elements. Can be null when undefined
 	 * @since 2.3
 	 */
 	public Class<? extends Dataset> getInterface() {
@@ -233,9 +234,9 @@ public class LazyDataset extends LazyDatasetBase implements Serializable, Clonea
 		int result = super.hashCode();
 		result = prime * result + Arrays.hashCode(oShape);
 		result = prime * result + (int) (size ^ (size >>> 32));
-		result = prime * result + clazz.hashCode();
+		result = prime * result + Objects.hashCode(clazz);
 		result = prime * result + isize;
-		result = prime * result + ((loader == null) ? 0 : loader.hashCode());
+		result = prime * result + Objects.hashCode(loader);
 		result = prime * result + Arrays.hashCode(begSlice);
 		result = prime * result + Arrays.hashCode(delSlice);
 		result = prime * result + Arrays.hashCode(sShape);
@@ -260,7 +261,7 @@ public class LazyDataset extends LazyDatasetBase implements Serializable, Clonea
 		if (size != other.size) {
 			return false;
 		}
-		if (!clazz.equals(other.clazz)) {
+		if (!Objects.equals(clazz, other.clazz)) {
 			return false;
 		}
 		if (isize != other.isize) {
@@ -399,7 +400,7 @@ public class LazyDataset extends LazyDatasetBase implements Serializable, Clonea
 
 		Dataset a;
 		if (nslice == null) {
-			a = DatasetFactory.zeros(clazz, slice.getShape());
+			a = DatasetFactory.zeros(clazz == null ? DoubleDataset.class : clazz, slice.getShape());
 		} else {
 			try {
 				a = DatasetUtils.convertToDataset(loader.getDataset(monitor, nslice));
@@ -432,6 +433,9 @@ public class LazyDataset extends LazyDatasetBase implements Serializable, Clonea
 		}
 		a.addMetadata(MetadataFactory.createMetadata(OriginMetadata.class, this, nslice == null ? slice.convertToSlice() : nslice.convertToSlice(), oShape, null, name));
 
+		if (clazz == null) {
+			clazz = a.getClass();
+		}
 		return a;
 	}
 

--- a/org.eclipse.january/src/org/eclipse/january/dataset/LazyDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/LazyDataset.java
@@ -143,11 +143,11 @@ public class LazyDataset extends LazyDatasetBase implements Serializable, Clonea
 	 * @param dataset
 	 */
 	public static LazyDataset createLazyDataset(final Dataset dataset) {
-		return new LazyDataset(dataset.getName(), dataset.getDType(), dataset.getElementsPerItem(), dataset.getShapeRef(),
-		new ILazyLoader() {
+		return new LazyDataset(new ILazyLoader() {
 			private static final long serialVersionUID = -6725268922780517523L;
 
 			final Dataset d = dataset;
+
 			@Override
 			public boolean isFileReadable() {
 				return true;
@@ -157,7 +157,7 @@ public class LazyDataset extends LazyDatasetBase implements Serializable, Clonea
 			public Dataset getDataset(IMonitor mon, SliceND slice) throws IOException {
 				return d.getSlice(mon, slice);
 			}
-		});
+		}, dataset.getName(), dataset.getElementsPerItem(), dataset.getClass(), dataset.getShapeRef());
 	}
 
 	/**
@@ -174,6 +174,15 @@ public class LazyDataset extends LazyDatasetBase implements Serializable, Clonea
 	 */
 	public Class<? extends Dataset> getInterface() {
 		return clazz;
+	}
+
+	/**
+	 * Set interface
+	 * @param clazz
+	 * @since 2.3
+	 */
+	public void setInterface(Class<? extends Dataset> clazz) {
+		this.clazz = clazz;
 	}
 
 	/**

--- a/org.eclipse.january/src/org/eclipse/january/dataset/LazyDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/LazyDataset.java
@@ -319,9 +319,9 @@ public class LazyDataset extends LazyDatasetBase implements Serializable, Clonea
 	@Override
 	public Dataset getSlice(Slice... slice) throws DatasetException {
 		if (slice == null || slice.length == 0) {
-			return getSlice(null, new SliceND(shape));
+			return internalGetSlice(null, new SliceND(shape));
 		}
-		return getSlice(null, new SliceND(shape, slice));
+		return internalGetSlice(null, new SliceND(shape, slice));
 	}
 
 	@Override
@@ -332,9 +332,9 @@ public class LazyDataset extends LazyDatasetBase implements Serializable, Clonea
 	@Override
 	public Dataset getSlice(IMonitor monitor, Slice... slice) throws DatasetException {
 		if (slice == null || slice.length == 0) {
-			return getSlice(monitor, new SliceND(shape));
+			return internalGetSlice(monitor, new SliceND(shape));
 		}
-		return getSlice(monitor, new SliceND(shape, slice));
+		return internalGetSlice(monitor, new SliceND(shape, slice));
 	}
 
 	@Override
@@ -365,11 +365,16 @@ public class LazyDataset extends LazyDatasetBase implements Serializable, Clonea
 
 	@Override
 	public LazyDataset getSliceView(int[] start, int[] stop, int[] step) {
-		return getSliceView(new SliceND(shape, start, stop, step));
+		return internalGetSliceView(new SliceND(shape, start, stop, step));
 	}
 
 	@Override
 	public LazyDataset getSliceView(SliceND slice) {
+		checkSliceND(slice);
+		return internalGetSliceView(slice);
+	}
+
+	protected LazyDataset internalGetSliceView(SliceND slice) {
 		LazyDataset view = clone();
 		if (slice.isAll()) {
 			return view;
@@ -391,11 +396,17 @@ public class LazyDataset extends LazyDatasetBase implements Serializable, Clonea
 
 	@Override
 	public Dataset getSlice(IMonitor monitor, int[] start, int[] stop, int[] step) throws DatasetException {
-		return getSlice(monitor, new SliceND(shape, start, stop, step));
+		return internalGetSlice(monitor, new SliceND(shape, start, stop, step));
 	}
 
 	@Override
 	public Dataset getSlice(IMonitor monitor, SliceND slice) throws DatasetException {
+		checkSliceND(slice);
+
+		return internalGetSlice(monitor, slice);
+	}
+
+	protected Dataset internalGetSlice(IMonitor monitor, SliceND slice) throws DatasetException {
 		if (loader != null && !loader.isFileReadable()) {
 			return null;
 		}

--- a/org.eclipse.january/src/org/eclipse/january/dataset/LazyDatasetBase.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/LazyDatasetBase.java
@@ -144,6 +144,29 @@ public abstract class LazyDatasetBase implements ILazyDataset, Serializable {
 		dirty = true;
 	}
 
+	protected void checkSliceND(SliceND slice) {
+		if (slice != null) {
+			int[] source = slice.getSourceShape();
+			boolean fail = false;
+			if (slice.isExpanded()) {
+				fail = shape.length != source.length;
+				if (!fail) {
+					for (int i = 0; i < shape.length; i++) {
+						if (shape[i] > source[i]) {
+							fail = true;
+							break;
+						}
+					}
+				}
+			} else {
+				fail = !Arrays.equals(shape, source);
+			}
+			if (fail) {
+				throw new IllegalArgumentException("Slice's shape must match dataset's shape");
+			}
+		}
+	}
+
 	/**
 	 * Find first sub-interface of (or class that directly implements) MetadataType
 	 * @param clazz
@@ -482,6 +505,7 @@ public abstract class LazyDatasetBase implements ILazyDataset, Serializable {
 					}
 				}
 				lz = lz.getSliceView(nslice);
+				shape = nslice.getShape();
 			}
 			if (lz.getSize() == oSize) {
 				nslice = slice;
@@ -497,6 +521,7 @@ public abstract class LazyDatasetBase implements ILazyDataset, Serializable {
 						throw new IllegalArgumentException("Sliceable dataset has non-unit dimension less than host!");
 					}
 				}
+				nslice.updateSourceShape(shape);
 			}
 
 			if (asView || (lz instanceof IDataset)) {

--- a/org.eclipse.january/src/org/eclipse/january/dataset/LazyDatasetBase.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/LazyDatasetBase.java
@@ -44,7 +44,7 @@ public abstract class LazyDatasetBase implements ILazyDataset, Serializable {
 
 	private static final long serialVersionUID = 767926846438976050L;
 
-	protected static final Logger logger = LoggerFactory.getLogger(LazyDatasetBase.class);
+	private static final Logger logger = LoggerFactory.getLogger(LazyDatasetBase.class);
 
 	protected static boolean catchExceptions;
 

--- a/org.eclipse.january/src/org/eclipse/january/dataset/LazyDatasetBase.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/LazyDatasetBase.java
@@ -46,20 +46,6 @@ public abstract class LazyDatasetBase implements ILazyDataset, Serializable {
 
 	private static final Logger logger = LoggerFactory.getLogger(LazyDatasetBase.class);
 
-	protected static boolean catchExceptions;
-
-	static {
-		/**
-		 * Boolean to set to true if running jython scripts that utilise ScisoftPy in IDE
-		 */
-		try {
-			catchExceptions = Boolean.getBoolean("run.in.eclipse");
-		} catch (SecurityException e) {
-			// set a default for when the security manager does not allow access to the requested key
-			catchExceptions = false;
-		}
-	}
-
 	transient private boolean dirty = true; // indicate dirty state of metadata
 	protected String name = "";
 
@@ -810,7 +796,7 @@ public abstract class LazyDatasetBase implements ILazyDataset, Serializable {
 	 * @param slice
 	 */
 	protected void sliceMetadata(boolean asView, final SliceND slice) {
-		processAnnotatedMetadata(new MdsSlice(asView, slice), true);
+		processAnnotatedMetadata(new MdsSlice(asView, slice));
 	}
 
 	/**
@@ -820,7 +806,7 @@ public abstract class LazyDatasetBase implements ILazyDataset, Serializable {
 	 * @param newShape
 	 */
 	protected void reshapeMetadata(final int[] oldShape, final int[] newShape) {
-		processAnnotatedMetadata(new MdsReshape(oldShape, newShape), true);
+		processAnnotatedMetadata(new MdsReshape(oldShape, newShape));
 	}
 
 	/**
@@ -829,7 +815,7 @@ public abstract class LazyDatasetBase implements ILazyDataset, Serializable {
 	 * @param axesMap
 	 */
 	protected void transposeMetadata(final int[] axesMap) {
-		processAnnotatedMetadata(new MdsTranspose(axesMap), true);
+		processAnnotatedMetadata(new MdsTranspose(axesMap));
 	}
 
 	/**
@@ -837,11 +823,11 @@ public abstract class LazyDatasetBase implements ILazyDataset, Serializable {
 	 * @since 2.0
 	 */
 	protected void dirtyMetadata() {
-		processAnnotatedMetadata(new MdsDirty(), true);
+		processAnnotatedMetadata(new MdsDirty());
 	}
 
 	@SuppressWarnings("unchecked")
-	private void processAnnotatedMetadata(MetadatasetAnnotationOperation op, boolean throwException) {
+	private void processAnnotatedMetadata(MetadatasetAnnotationOperation op) {
 		if (metadata == null)
 			return;
 
@@ -853,7 +839,7 @@ public abstract class LazyDatasetBase implements ILazyDataset, Serializable {
 
 				Class<? extends MetadataType> mc = m.getClass();
 				do { // iterate over super-classes
-					processClass(op, m, mc, throwException);
+					processClass(op, m, mc);
 					Class<?> sclazz = mc.getSuperclass();
 					if (!MetadataType.class.isAssignableFrom(sclazz)) {
 						break;
@@ -865,7 +851,7 @@ public abstract class LazyDatasetBase implements ILazyDataset, Serializable {
 	}
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })
-	private static void processClass(MetadatasetAnnotationOperation op, MetadataType m, Class<? extends MetadataType> mc, boolean throwException) {
+	private static void processClass(MetadatasetAnnotationOperation op, MetadataType m, Class<? extends MetadataType> mc) {
 		for (Field f : mc.getDeclaredFields()) {
 			if (!f.isAnnotationPresent(op.getAnnClass()))
 				continue;
@@ -888,9 +874,7 @@ public abstract class LazyDatasetBase implements ILazyDataset, Serializable {
 						f.set(m, op.run((ILazyDataset) o));
 					} catch (Exception e) {
 						logger.error("Problem processing " + o, e);
-						if (!catchExceptions) {
-							throw e;
-						}
+						throw e;
 					}
 				} else if (o.getClass().isArray()) {
 					int l = Array.getLength(o);
@@ -970,9 +954,7 @@ public abstract class LazyDatasetBase implements ILazyDataset, Serializable {
 				}
 			} catch (Exception e) {
 				logger.error("Problem occurred when processing metadata of class {}: {}", mc.getCanonicalName(), e);
-				if (throwException) {
-					throw new RuntimeException(e);
-				} 
+				throw new RuntimeException(e);
 			}
 		}
 	}
@@ -988,9 +970,7 @@ public abstract class LazyDatasetBase implements ILazyDataset, Serializable {
 				return op.run((ILazyDataset) o);
 			} catch (Exception e) {
 				logger.error("Problem processing " + o, e);
-				if (!catchExceptions) {
-					throw e;
-				}
+				throw e;
 			}
 		} else if (o.getClass().isArray()) {
 			int l = Array.getLength(o);

--- a/org.eclipse.january/src/org/eclipse/january/dataset/LazyDatasetBase.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/LazyDatasetBase.java
@@ -76,11 +76,6 @@ public abstract class LazyDatasetBase implements ILazyDataset, Serializable {
 	abstract public int getDType();
 
 	@Override
-	public Class<?> getElementClass() {
-		return DTypeUtils.getElementClass(getDType());
-	}
-
-	@Override
 	public LazyDatasetBase clone() {
 		return null;
 	}

--- a/org.eclipse.january/src/org/eclipse/january/dataset/LazyDynamicDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/LazyDynamicDataset.java
@@ -45,8 +45,49 @@ public class LazyDynamicDataset extends LazyDataset implements IDynamicDataset {
 
 	private Thread checkingThread;
 
+	/**
+	 * Create a dynamic lazy dataset
+	 * @param name
+	 * @param dtype
+	 * @param elements
+	 * @param shape
+	 * @param maxShape
+	 * @param loader
+	 * @deprecated Use {@link #LazyDynamicDataset(ILazyLoader, String, int, Class, int[], int[])}
+	 */
+	@Deprecated
 	public LazyDynamicDataset(String name, int dtype, int elements, int[] shape, int[] maxShape, ILazyLoader loader) {
-		super(name, dtype, elements, shape, loader);
+		this(name, elements, DTypeUtils.getInterface(dtype), shape, maxShape, loader);
+	}
+
+	/**
+	 * Create a dynamic lazy dataset
+	 * @param name
+	 * @param elements
+	 * @param clazz
+	 * @param shape
+	 * @param maxShape
+	 * @param loader
+	 * @since 2.3
+	 * @deprecated Use {@link #LazyDynamicDataset(ILazyLoader, String, int, Class, int[], int[])}
+	 */
+	@Deprecated
+	public LazyDynamicDataset(String name, int elements, Class<? extends Dataset> clazz, int[] shape, int[] maxShape, ILazyLoader loader) {
+		this(loader, name, elements, clazz, shape, maxShape);
+	}
+
+	/**
+	 * Create a dynamic lazy dataset
+	 * @param loader
+	 * @param name
+	 * @param elements
+	 * @param clazz
+	 * @param shape
+	 * @param maxShape
+	 * @since 2.3
+	 */
+	public LazyDynamicDataset(ILazyLoader loader, String name, int elements, Class<? extends Dataset> clazz, int[] shape, int[] maxShape) {
+		super(loader, name, elements, clazz, shape);
 		if (maxShape == null) {
 			this.maxShape = shape.clone();
 			// check there are no unlimited dimensions in shape

--- a/org.eclipse.january/src/org/eclipse/january/dataset/LazyMaths.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/LazyMaths.java
@@ -31,7 +31,7 @@ public final class LazyMaths {
 	/**
 	 * Setup the logging facilities
 	 */
-	protected static final Logger logger = LoggerFactory.getLogger(LazyMaths.class);
+	private static final Logger logger = LoggerFactory.getLogger(LazyMaths.class);
 
 	// TODO Uncomment this next line when minimum JDK is set to 1.8
 	// @FunctionalInterface

--- a/org.eclipse.january/src/org/eclipse/january/dataset/LazyWriteableDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/LazyWriteableDataset.java
@@ -171,7 +171,7 @@ public class LazyWriteableDataset extends LazyDynamicDataset implements ILazyWri
 				if (slice.isExpanded()) {
 					Dataset od = d;
 					d = DatasetFactory.zeros(od.getClass(), slice.getSourceShape());
-					d.setSlice(od, SliceND.createSlice(od, null, null));
+					d.setSlice(od, SliceND.createSlice(d, null, od.getShapeRef()));
 				}
 				d.setSlice(data, slice);
 			}
@@ -281,11 +281,13 @@ public class LazyWriteableDataset extends LazyDynamicDataset implements ILazyWri
 
 	@Override
 	public void setSlice(IMonitor monitor, IDataset data, SliceND slice) throws DatasetException {
+		checkSliceND(slice);
 		internalSetSlice(monitor, writeAsync, data, slice);
 	}
 
 	@Override
 	public void setSliceSync(IMonitor monitor, IDataset data, SliceND slice) throws DatasetException {
+		checkSliceND(slice);
 		internalSetSlice(monitor, false, data, slice);
 	}
 

--- a/org.eclipse.january/src/org/eclipse/january/dataset/LazyWriteableDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/LazyWriteableDataset.java
@@ -36,9 +36,40 @@ public class LazyWriteableDataset extends LazyDynamicDataset implements ILazyWri
 	 * @param maxShape
 	 * @param chunks
 	 * @param saver
+	 * @deprecated Use {@link #LazyWriteableDataset(ILazySaver, String, int, Class, int[], int[], int[])}
 	 */
+	@Deprecated
 	public LazyWriteableDataset(String name, int dtype, int elements, int[] shape, int[] maxShape, int[] chunks, ILazySaver saver) {
-		super(name, dtype, elements, shape, maxShape, saver);
+		this(saver, name, elements, DTypeUtils.getInterface(dtype), shape, maxShape, chunks);
+	}
+
+	/**
+	 * Create a lazy dataset
+	 * @param name
+	 * @param clazz dataset interface
+	 * @param shape
+	 * @param maxShape
+	 * @param chunks
+	 * @param saver
+	 * @since 2.3
+	 */
+	public LazyWriteableDataset(ILazySaver saver, String name, Class<? extends Dataset> clazz, int[] shape, int[] maxShape, int[] chunks) {
+		this(saver, name, 1, clazz, shape, maxShape, chunks);
+	}
+
+	/**
+	 * Create a lazy dataset
+	 * @param name
+	 * @param elements
+	 * @param clazz dataset interface
+	 * @param shape
+	 * @param maxShape
+	 * @param chunks
+	 * @param saver
+	 * @since 2.3
+	 */
+	public LazyWriteableDataset(ILazySaver saver, String name, int elements, Class<? extends Dataset> clazz, int[] shape, int[] maxShape, int[] chunks) {
+		super(saver, name, elements, clazz, shape, maxShape);
 		this.chunks = chunks == null ? null : chunks.clone();
 		this.saver = saver;
 
@@ -53,7 +84,9 @@ public class LazyWriteableDataset extends LazyDynamicDataset implements ILazyWri
 	 * @param maxShape
 	 * @param chunks
 	 * @param saver
+	 * @deprecated Use {@link #LazyWriteableDataset(ILazySaver, String, int, Class, int[], int[], int[])}
 	 */
+	@Deprecated
 	public LazyWriteableDataset(String name, int dtype, int[] shape, int[] maxShape, int[] chunks, ILazySaver saver) {
 		this(name, dtype, 1, shape, maxShape, chunks, saver);
 	}
@@ -69,7 +102,7 @@ public class LazyWriteableDataset extends LazyDynamicDataset implements ILazyWri
 	 * @param saver
 	 */
 	public LazyWriteableDataset(String name, Class<?> clazz, int elements, int[] shape, int[] maxShape, int[] chunks, ILazySaver saver) {
-		this(name, DTypeUtils.getDTypeFromClass(clazz), elements, shape, maxShape, chunks, saver);
+		this(saver, name, elements, InterfaceUtils.getInterfaceFromClass(elements, clazz), shape, maxShape, chunks);
 	}
 
 	/**
@@ -82,7 +115,7 @@ public class LazyWriteableDataset extends LazyDynamicDataset implements ILazyWri
 	 * @param saver
 	 */
 	public LazyWriteableDataset(String name, Class<?> clazz, int[] shape, int[] maxShape, int[] chunks, ILazySaver saver) {
-		this(name, DTypeUtils.getDTypeFromClass(clazz), 1, shape, maxShape, chunks, saver);
+		this(saver, name, 1, InterfaceUtils.getInterfaceFromClass(1, clazz), shape, maxShape, chunks);
 	}
 
 	/**
@@ -110,9 +143,7 @@ public class LazyWriteableDataset extends LazyDynamicDataset implements ILazyWri
 	 * @param dataset
 	 */
 	public static LazyWriteableDataset createLazyDataset(final Dataset dataset, final int[] maxShape) {
-		return new LazyWriteableDataset(dataset.getName(), dataset.getDType(), dataset.getElementsPerItem(), dataset.getShapeRef(),
-				maxShape, null,
-		new ILazySaver() {
+		return new LazyWriteableDataset(new ILazySaver() {
 			private static final long serialVersionUID = ILazySaver.serialVersionUID;
 
 			Dataset d = dataset;
@@ -144,7 +175,8 @@ public class LazyWriteableDataset extends LazyDynamicDataset implements ILazyWri
 				}
 				d.setSlice(data, slice);
 			}
-		});
+		},
+		dataset.getName(), dataset.getElementsPerItem(), dataset.getClass(), dataset.getShapeRef(), maxShape, null);
 	}
 
 	@Override

--- a/org.eclipse.january/src/org/eclipse/january/dataset/LongDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/LongDataset.java
@@ -52,11 +52,6 @@ public class LongDataset extends AbstractDataset {
 		return array;
 	}
 
-	@Override
-	public int getDType() {
-		return INT64; // DATA_TYPE
-	}
-
 	/**
 	 * Create a null dataset
 	 */

--- a/org.eclipse.january/src/org/eclipse/january/dataset/LongDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/LongDataset.java
@@ -22,6 +22,8 @@ import java.util.TreeSet;
 
 import org.apache.commons.math3.complex.Complex;
 import org.eclipse.january.metadata.StatisticsMetadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -30,6 +32,8 @@ import org.eclipse.january.metadata.StatisticsMetadata;
 public class LongDataset extends AbstractDataset {
 	// pin UID to base class
 	private static final long serialVersionUID = Dataset.serialVersionUID;
+
+	private static final Logger logger = LoggerFactory.getLogger(LongDataset.class);
 
 	protected long[] data; // subclass alias // PRIM_TYPE
 

--- a/org.eclipse.january/src/org/eclipse/january/dataset/Maths.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/Maths.java
@@ -7433,7 +7433,7 @@ public class Maths {
 								q = (float) (ibx / iby);
 								den = (float) (ibx * q + iby);
 								ox = (float) ((iax * q + iay) / den);
-								oy = (float) ((iay * q - ibx) / den);
+								oy = (float) ((iay * q - iax) / den);
 							} else {
 								q = (float) (iby / ibx);
 								den = (float) (iby * q + ibx);
@@ -7500,7 +7500,7 @@ public class Maths {
 						q = (float) (ibx / iby);
 						den = (float) (ibx * q + iby);
 						ox = (float) ((iax * q + iay) / den);
-						oy = (float) ((iay * q - ibx) / den);
+						oy = (float) ((iay * q - iax) / den);
 					} else {
 						q = (float) (iby / ibx);
 						den = (float) (iby * q + ibx);
@@ -7536,7 +7536,7 @@ public class Maths {
 								q = (ibx / iby);
 								den = (ibx * q + iby);
 								ox = ((iax * q + iay) / den);
-								oy = ((iay * q - ibx) / den);
+								oy = ((iay * q - iax) / den);
 							} else {
 								q = (iby / ibx);
 								den = (iby * q + ibx);
@@ -7603,7 +7603,7 @@ public class Maths {
 						q = (ibx / iby);
 						den = (ibx * q + iby);
 						ox = ((iax * q + iay) / den);
-						oy = ((iay * q - ibx) / den);
+						oy = ((iay * q - iax) / den);
 					} else {
 						q = (iby / ibx);
 						den = (iby * q + ibx);
@@ -8586,7 +8586,7 @@ public class Maths {
 								q = (float) (ibx / iby);
 								den = (float) (ibx * q + iby);
 								ox = (float) ((iax * q + iay) / den);
-								oy = (float) ((iay * q - ibx) / den);
+								oy = (float) ((iay * q - iax) / den);
 							} else {
 								q = (float) (iby / ibx);
 								den = (float) (iby * q + ibx);
@@ -8665,7 +8665,7 @@ public class Maths {
 						q = (float) (ibx / iby);
 						den = (float) (ibx * q + iby);
 						ox = (float) ((iax * q + iay) / den);
-						oy = (float) ((iay * q - ibx) / den);
+						oy = (float) ((iay * q - iax) / den);
 					} else {
 						q = (float) (iby / ibx);
 						den = (float) (iby * q + ibx);
@@ -8698,7 +8698,7 @@ public class Maths {
 								q = (ibx / iby);
 								den = (ibx * q + iby);
 								ox = ((iax * q + iay) / den);
-								oy = ((iay * q - ibx) / den);
+								oy = ((iay * q - iax) / den);
 							} else {
 								q = (iby / ibx);
 								den = (iby * q + ibx);
@@ -8777,7 +8777,7 @@ public class Maths {
 						q = (ibx / iby);
 						den = (ibx * q + iby);
 						ox = ((iax * q + iay) / den);
-						oy = ((iay * q - ibx) / den);
+						oy = ((iay * q - iax) / den);
 					} else {
 						q = (iby / ibx);
 						den = (iby * q + ibx);
@@ -10267,7 +10267,7 @@ public class Maths {
 								q = (float) (ibx / iby);
 								den = (float) (ibx * q + iby);
 								ox = (float) ((iax * q + iay) / den);
-								oy = (float) ((iay * q - ibx) / den);
+								oy = (float) ((iay * q - iax) / den);
 							} else {
 								q = (float) (iby / ibx);
 								den = (float) (iby * q + ibx);
@@ -10334,7 +10334,7 @@ public class Maths {
 						q = (float) (ibx / iby);
 						den = (float) (ibx * q + iby);
 						ox = (float) ((iax * q + iay) / den);
-						oy = (float) ((iay * q - ibx) / den);
+						oy = (float) ((iay * q - iax) / den);
 					} else {
 						q = (float) (iby / ibx);
 						den = (float) (iby * q + ibx);
@@ -10370,7 +10370,7 @@ public class Maths {
 								q = (ibx / iby);
 								den = (ibx * q + iby);
 								ox = ((iax * q + iay) / den);
-								oy = ((iay * q - ibx) / den);
+								oy = ((iay * q - iax) / den);
 							} else {
 								q = (iby / ibx);
 								den = (iby * q + ibx);
@@ -10437,7 +10437,7 @@ public class Maths {
 						q = (ibx / iby);
 						den = (ibx * q + iby);
 						ox = ((iax * q + iay) / den);
-						oy = ((iay * q - ibx) / den);
+						oy = ((iay * q - iax) / den);
 					} else {
 						q = (iby / ibx);
 						den = (iby * q + ibx);

--- a/org.eclipse.january/src/org/eclipse/january/dataset/Maths.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/Maths.java
@@ -2696,51 +2696,37 @@ public class Maths {
 		return ds;
 	}
 
-	private static double SelectedMean(Dataset data, int Min, int Max) {
-
+	private static double selectedMean(Dataset data, int min, int max) {
 		double result = 0.0;
-		for (int i = Min, imax = data.getSize(); i <= Max; i++) {
+		for (int i = min, end = data.getSize() - 1; i <= max; i++) {
 			// clip i appropriately, imagine that effectively the two ends
-			// continue
-			// straight out.
-			int pos = i;
-			if (pos < 0) {
-				pos = 0;
-			} else if (pos >= imax) {
-				pos = imax - 1;
-			}
-			result += data.getElementDoubleAbs(pos);
+			// continue straight out.
+			int pos = Math.min(Math.max(0, i), end);
+			result += data.getDouble(pos);
 		}
 
 		// now the sum is complete, average the values.
-		result /= (Max - Min) + 1;
+		result /= (max - min) + 1;
 		return result;
 	}
 
-	private static void SelectedMeanArray(double[] out, Dataset data, int Min, int Max) {
+	private static void selectedMeanArray(double[] out, Dataset data, int min, int max) {
+		Arrays.fill(out, 0);
 		final int isize = out.length;
-		for (int j = 0; j < isize; j++)
-			out[j] = 0.;
-
-		for (int i = Min, imax = data.getSize(); i <= Max; i++) {
+		for (int i = min, end = data.getSize() - 1; i <= max; i++) {
 			// clip i appropriately, imagine that effectively the two ends
-			// continue
-			// straight out.
-			int pos = i * isize;
-			if (pos < 0) {
-				pos = 0;
-			} else if (pos >= imax) {
-				pos = imax - isize;
+			// continue straight out.
+			int off = data.get1DIndex(Math.min(Math.max(0, i), end));
+			for (int j = 0; j < isize; j++) {
+				out[j] += data.getElementDoubleAbs(off++);
 			}
-			for (int j = 0; j < isize; j++)
-				out[j] += data.getElementDoubleAbs(pos + j);
 		}
 
 		// now the sum is complete, average the values.
-		double norm = 1. / (Max - Min + 1.);
-		for (int j = 0; j < isize; j++)
+		double norm = 1. / (max - min + 1.);
+		for (int j = 0; j < isize; j++) {
 			out[j] *= norm;
-
+		}
 	}
 
 	/**
@@ -2794,10 +2780,10 @@ public class Maths {
 		final int isize = y.getElementsPerItem();
 		if (isize == 1) {
 			for (int i = 0, imax = x.getSize(); i < imax; i++) {
-				double LeftValue = SelectedMean(y, i - n, i - 1);
-				double RightValue = SelectedMean(y, i + 1, i + n);
-				double LeftPosition = SelectedMean(x, i - n, i - 1);
-				double RightPosition = SelectedMean(x, i + 1, i + n);
+				double LeftValue = selectedMean(y, i - n, i - 1);
+				double RightValue = selectedMean(y, i + 1, i + n);
+				double LeftPosition = selectedMean(x, i - n, i - 1);
+				double RightPosition = selectedMean(x, i + 1, i + n);
 
 				// now the values and positions are calculated, the derivative
 				// can be
@@ -2808,10 +2794,10 @@ public class Maths {
 			double[] leftValues = new double[isize];
 			double[] rightValues = new double[isize];
 			for (int i = 0, imax = x.getSize(); i < imax; i++) {
-				SelectedMeanArray(leftValues, y, i - n, i - 1);
-				SelectedMeanArray(rightValues, y, i + 1, i + n);
-				double delta = SelectedMean(x, i - n, i - 1);
-				delta = 1. / (SelectedMean(x, i + 1, i + n) - delta);
+				selectedMeanArray(leftValues, y, i - n, i - 1);
+				selectedMeanArray(rightValues, y, i + 1, i + n);
+				double delta = selectedMean(x, i - n, i - 1);
+				delta = 1. / (selectedMean(x, i + 1, i + n) - delta);
 				for (int j = 0; j < isize; j++) {
 					rightValues[j] -= leftValues[j];
 					rightValues[j] *= delta;

--- a/org.eclipse.january/src/org/eclipse/january/dataset/Maths.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/Maths.java
@@ -7447,28 +7447,10 @@ public class Maths {
 						while (it.hasNext()) {
 							final double iax = it.aDouble;
 							final double ibx = it.bDouble;
-							final double iby = 0;
 							float ox;
 							float oy;
-							float q;
-							float den;
-							if (iby == 0) {
-								ox = (float) (iax / ibx);
-								oy = (float) (iay / ibx);
-							} else if (ibx == 0) {
-								ox = (float) (iay / iby);
-								oy = (float) (-iax / iby);
-							} else if (Math.abs(ibx) < Math.abs(iby)) {
-								q = (float) (ibx / iby);
-								den = (float) (ibx * q + iby);
-								ox = (float) ((iax * q + iay) / den);
-								oy = (float) ((iay * q - ibx) / den);
-							} else {
-								q = (float) (iby / ibx);
-								den = (float) (iby * q + ibx);
-								ox = (float) ((iay * q + iax) / den);
-								oy = (float) ((iay - iax * q) / den);
-							}
+							ox = (float) (iax / ibx);
+							oy = (float) (iay / ibx);
 							oc64data[it.oIndex] = ox;
 							oc64data[it.oIndex + 1] = oy;
 						}
@@ -7478,59 +7460,23 @@ public class Maths {
 					while (it.hasNext()) {
 						final long iax = it.aLong;
 						final long ibx = it.bLong;
-						final long iby = 0;
 						float ox;
 						float oy;
-						float q;
-						float den;
-						if (iby == 0) {
-							ox = (float) (iax / ibx);
-							oy = (float) (iay / ibx);
-						} else if (ibx == 0) {
-							ox = (float) (iay / iby);
-							oy = (float) (-iax / iby);
-						} else if (Math.abs(ibx) < Math.abs(iby)) {
-							q = (float) (ibx / iby);
-							den = (float) (ibx * q + iby);
-							ox = (float) ((iax * q + iay) / den);
-							oy = (float) ((iay * q - ibx) / den);
-						} else {
-							q = (float) (iby / ibx);
-							den = (float) (iby * q + ibx);
-							ox = (float) ((iay * q + iax) / den);
-							oy = (float) ((iay - iax * q) / den);
-						}
+						ox = (float) (iax / ibx);
+						oy = (float) (iay / ibx);
 						oc64data[it.oIndex] = ox;
 						oc64data[it.oIndex + 1] = oy;
 					}
 				}
 			} else if (!db.isComplex()) {
-				final double iby = 0;
 				while (it.hasNext()) {
 					final double iax = it.aDouble;
 					final double ibx = it.bDouble;
 					final double iay = da.getElementDoubleAbs(it.aIndex + 1);
 					float ox;
 					float oy;
-					float q;
-					float den;
-					if (iby == 0) {
-						ox = (float) (iax / ibx);
-						oy = (float) (iay / ibx);
-					} else if (ibx == 0) {
-						ox = (float) (iay / iby);
-						oy = (float) (-iax / iby);
-					} else if (Math.abs(ibx) < Math.abs(iby)) {
-						q = (float) (ibx / iby);
-						den = (float) (ibx * q + iby);
-						ox = (float) ((iax * q + iay) / den);
-						oy = (float) ((iay * q - ibx) / den);
-					} else {
-						q = (float) (iby / ibx);
-						den = (float) (iby * q + ibx);
-						ox = (float) ((iay * q + iax) / den);
-						oy = (float) ((iay - iax * q) / den);
-					}
+					ox = (float) (iax / ibx);
+					oy = (float) (iay / ibx);
 					oc64data[it.oIndex] = ox;
 					oc64data[it.oIndex + 1] = oy;
 				}
@@ -7604,28 +7550,10 @@ public class Maths {
 						while (it.hasNext()) {
 							final double iax = it.aDouble;
 							final double ibx = it.bDouble;
-							final double iby = 0;
 							double ox;
 							double oy;
-							double q;
-							double den;
-							if (iby == 0) {
-								ox = (iax / ibx);
-								oy = (iay / ibx);
-							} else if (ibx == 0) {
-								ox = (iay / iby);
-								oy = (-iax / iby);
-							} else if (Math.abs(ibx) < Math.abs(iby)) {
-								q = (ibx / iby);
-								den = (ibx * q + iby);
-								ox = ((iax * q + iay) / den);
-								oy = ((iay * q - ibx) / den);
-							} else {
-								q = (iby / ibx);
-								den = (iby * q + ibx);
-								ox = ((iay * q + iax) / den);
-								oy = ((iay - iax * q) / den);
-							}
+							ox = (iax / ibx);
+							oy = (iay / ibx);
 							oc128data[it.oIndex] = ox;
 							oc128data[it.oIndex + 1] = oy;
 						}
@@ -7635,59 +7563,23 @@ public class Maths {
 					while (it.hasNext()) {
 						final long iax = it.aLong;
 						final long ibx = it.bLong;
-						final long iby = 0;
 						double ox;
 						double oy;
-						double q;
-						double den;
-						if (iby == 0) {
-							ox = (iax / ibx);
-							oy = (iay / ibx);
-						} else if (ibx == 0) {
-							ox = (iay / iby);
-							oy = (-iax / iby);
-						} else if (Math.abs(ibx) < Math.abs(iby)) {
-							q = (ibx / iby);
-							den = (ibx * q + iby);
-							ox = ((iax * q + iay) / den);
-							oy = ((iay * q - ibx) / den);
-						} else {
-							q = (iby / ibx);
-							den = (iby * q + ibx);
-							ox = ((iay * q + iax) / den);
-							oy = ((iay - iax * q) / den);
-						}
+						ox = (iax / ibx);
+						oy = (iay / ibx);
 						oc128data[it.oIndex] = ox;
 						oc128data[it.oIndex + 1] = oy;
 					}
 				}
 			} else if (!db.isComplex()) {
-				final double iby = 0;
 				while (it.hasNext()) {
 					final double iax = it.aDouble;
 					final double ibx = it.bDouble;
 					final double iay = da.getElementDoubleAbs(it.aIndex + 1);
 					double ox;
 					double oy;
-					double q;
-					double den;
-					if (iby == 0) {
-						ox = (iax / ibx);
-						oy = (iay / ibx);
-					} else if (ibx == 0) {
-						ox = (iay / iby);
-						oy = (-iax / iby);
-					} else if (Math.abs(ibx) < Math.abs(iby)) {
-						q = (ibx / iby);
-						den = (ibx * q + iby);
-						ox = ((iax * q + iay) / den);
-						oy = ((iay * q - ibx) / den);
-					} else {
-						q = (iby / ibx);
-						den = (iby * q + ibx);
-						ox = ((iay * q + iax) / den);
-						oy = ((iay - iax * q) / den);
-					}
+					ox = (iax / ibx);
+					oy = (iay / ibx);
 					oc128data[it.oIndex] = ox;
 					oc128data[it.oIndex + 1] = oy;
 				}
@@ -8708,24 +8600,14 @@ public class Maths {
 						while (it.hasNext()) {
 							final double iax = it.aDouble;
 							final double ibx = it.bDouble;
-							final double iby = 0;
 							float ox;
 							float oy;
-							float q;
-							float den;
-							if (ibx == 0 && iby == 0) {
+							if (ibx == 0) {
 								ox = 0;
 								oy = 0;
-							} else if (Math.abs(ibx) < Math.abs(iby)) {
-								q = (float) (ibx / iby);
-								den = (float) (ibx * q + iby);
-								ox = (float) ((iax * q + iay) / den);
-								oy = (float) ((iay * q - ibx) / den);
 							} else {
-								q = (float) (iby / ibx);
-								den = (float) (iby * q + ibx);
-								ox = (float) ((iay * q + iax) / den);
-								oy = (float) ((iay - iax * q) / den);
+								ox = (float) (iax / ibx);
+								oy = (float) (iay / ibx);
 							}
 							oc64data[it.oIndex] = ox;
 							oc64data[it.oIndex + 1] = oy;
@@ -8736,52 +8618,32 @@ public class Maths {
 					while (it.hasNext()) {
 						final long iax = it.aLong;
 						final long ibx = it.bLong;
-						final long iby = 0;
 						float ox;
 						float oy;
-						float q;
-						float den;
-						if (ibx == 0 && iby == 0) {
+						if (ibx == 0) {
 							ox = 0;
 							oy = 0;
-						} else if (Math.abs(ibx) < Math.abs(iby)) {
-							q = (float) (ibx / iby);
-							den = (float) (ibx * q + iby);
-							ox = (float) ((iax * q + iay) / den);
-							oy = (float) ((iay * q - ibx) / den);
 						} else {
-							q = (float) (iby / ibx);
-							den = (float) (iby * q + ibx);
-							ox = (float) ((iay * q + iax) / den);
-							oy = (float) ((iay - iax * q) / den);
+							ox = (float) (iax / ibx);
+							oy = (float) (iay / ibx);
 						}
 						oc64data[it.oIndex] = ox;
 						oc64data[it.oIndex + 1] = oy;
 					}
 				}
 			} else if (!db.isComplex()) {
-				final double iby = 0;
 				while (it.hasNext()) {
 					final double iax = it.aDouble;
 					final double ibx = it.bDouble;
 					final double iay = da.getElementDoubleAbs(it.aIndex + 1);
 					float ox;
 					float oy;
-					float q;
-					float den;
-					if (ibx == 0 && iby == 0) {
+					if (ibx == 0) {
 						ox = 0;
 						oy = 0;
-					} else if (Math.abs(ibx) < Math.abs(iby)) {
-						q = (float) (ibx / iby);
-						den = (float) (ibx * q + iby);
-						ox = (float) ((iax * q + iay) / den);
-						oy = (float) ((iay * q - ibx) / den);
 					} else {
-						q = (float) (iby / ibx);
-						den = (float) (iby * q + ibx);
-						ox = (float) ((iay * q + iax) / den);
-						oy = (float) ((iay - iax * q) / den);
+						ox = (float) (iax / ibx);
+						oy = (float) (iay / ibx);
 					}
 					oc64data[it.oIndex] = ox;
 					oc64data[it.oIndex + 1] = oy;
@@ -8850,24 +8712,14 @@ public class Maths {
 						while (it.hasNext()) {
 							final double iax = it.aDouble;
 							final double ibx = it.bDouble;
-							final double iby = 0;
 							double ox;
 							double oy;
-							double q;
-							double den;
-							if (ibx == 0 && iby == 0) {
+							if (ibx == 0) {
 								ox = 0;
 								oy = 0;
-							} else if (Math.abs(ibx) < Math.abs(iby)) {
-								q = (ibx / iby);
-								den = (ibx * q + iby);
-								ox = ((iax * q + iay) / den);
-								oy = ((iay * q - ibx) / den);
 							} else {
-								q = (iby / ibx);
-								den = (iby * q + ibx);
-								ox = ((iay * q + iax) / den);
-								oy = ((iay - iax * q) / den);
+								ox = (iax / ibx);
+								oy = (iay / ibx);
 							}
 							oc128data[it.oIndex] = ox;
 							oc128data[it.oIndex + 1] = oy;
@@ -8878,52 +8730,32 @@ public class Maths {
 					while (it.hasNext()) {
 						final long iax = it.aLong;
 						final long ibx = it.bLong;
-						final long iby = 0;
 						double ox;
 						double oy;
-						double q;
-						double den;
-						if (ibx == 0 && iby == 0) {
+						if (ibx == 0) {
 							ox = 0;
 							oy = 0;
-						} else if (Math.abs(ibx) < Math.abs(iby)) {
-							q = (ibx / iby);
-							den = (ibx * q + iby);
-							ox = ((iax * q + iay) / den);
-							oy = ((iay * q - ibx) / den);
 						} else {
-							q = (iby / ibx);
-							den = (iby * q + ibx);
-							ox = ((iay * q + iax) / den);
-							oy = ((iay - iax * q) / den);
+							ox = (iax / ibx);
+							oy = (iay / ibx);
 						}
 						oc128data[it.oIndex] = ox;
 						oc128data[it.oIndex + 1] = oy;
 					}
 				}
 			} else if (!db.isComplex()) {
-				final double iby = 0;
 				while (it.hasNext()) {
 					final double iax = it.aDouble;
 					final double ibx = it.bDouble;
 					final double iay = da.getElementDoubleAbs(it.aIndex + 1);
 					double ox;
 					double oy;
-					double q;
-					double den;
-					if (ibx == 0 && iby == 0) {
+					if (ibx == 0) {
 						ox = 0;
 						oy = 0;
-					} else if (Math.abs(ibx) < Math.abs(iby)) {
-						q = (ibx / iby);
-						den = (ibx * q + iby);
-						ox = ((iax * q + iay) / den);
-						oy = ((iay * q - ibx) / den);
 					} else {
-						q = (iby / ibx);
-						den = (iby * q + ibx);
-						ox = ((iay * q + iax) / den);
-						oy = ((iay - iax * q) / den);
+						ox = (iax / ibx);
+						oy = (iay / ibx);
 					}
 					oc128data[it.oIndex] = ox;
 					oc128data[it.oIndex + 1] = oy;
@@ -10449,28 +10281,10 @@ public class Maths {
 						while (it.hasNext()) {
 							final double iax = it.aDouble;
 							final double ibx = it.bDouble;
-							final double iby = 0;
 							float ox;
 							float oy;
-							float q;
-							float den;
-							if (iby == 0) {
-								ox = (float) (iax / ibx);
-								oy = (float) (iay / ibx);
-							} else if (ibx == 0) {
-								ox = (float) (iay / iby);
-								oy = (float) (-iax / iby);
-							} else if (Math.abs(ibx) < Math.abs(iby)) {
-								q = (float) (ibx / iby);
-								den = (float) (ibx * q + iby);
-								ox = (float) ((iax * q + iay) / den);
-								oy = (float) ((iay * q - ibx) / den);
-							} else {
-								q = (float) (iby / ibx);
-								den = (float) (iby * q + ibx);
-								ox = (float) ((iay * q + iax) / den);
-								oy = (float) ((iay - iax * q) / den);
-							}
+							ox = (float) (iax / ibx);
+							oy = (float) (iay / ibx);
 							oc64data[it.oIndex] = ox;
 							oc64data[it.oIndex + 1] = oy;
 						}
@@ -10480,59 +10294,23 @@ public class Maths {
 					while (it.hasNext()) {
 						final long iax = it.aLong;
 						final long ibx = it.bLong;
-						final long iby = 0;
 						float ox;
 						float oy;
-						float q;
-						float den;
-						if (iby == 0) {
-							ox = (float) (iax / ibx);
-							oy = (float) (iay / ibx);
-						} else if (ibx == 0) {
-							ox = (float) (iay / iby);
-							oy = (float) (-iax / iby);
-						} else if (Math.abs(ibx) < Math.abs(iby)) {
-							q = (float) (ibx / iby);
-							den = (float) (ibx * q + iby);
-							ox = (float) ((iax * q + iay) / den);
-							oy = (float) ((iay * q - ibx) / den);
-						} else {
-							q = (float) (iby / ibx);
-							den = (float) (iby * q + ibx);
-							ox = (float) ((iay * q + iax) / den);
-							oy = (float) ((iay - iax * q) / den);
-						}
+						ox = (float) (iax / ibx);
+						oy = (float) (iay / ibx);
 						oc64data[it.oIndex] = ox;
 						oc64data[it.oIndex + 1] = oy;
 					}
 				}
 			} else if (!db.isComplex()) {
-				final double iby = 0;
 				while (it.hasNext()) {
 					final double iax = it.aDouble;
 					final double ibx = it.bDouble;
 					final double iay = da.getElementDoubleAbs(it.aIndex + 1);
 					float ox;
 					float oy;
-					float q;
-					float den;
-					if (iby == 0) {
-						ox = (float) (iax / ibx);
-						oy = (float) (iay / ibx);
-					} else if (ibx == 0) {
-						ox = (float) (iay / iby);
-						oy = (float) (-iax / iby);
-					} else if (Math.abs(ibx) < Math.abs(iby)) {
-						q = (float) (ibx / iby);
-						den = (float) (ibx * q + iby);
-						ox = (float) ((iax * q + iay) / den);
-						oy = (float) ((iay * q - ibx) / den);
-					} else {
-						q = (float) (iby / ibx);
-						den = (float) (iby * q + ibx);
-						ox = (float) ((iay * q + iax) / den);
-						oy = (float) ((iay - iax * q) / den);
-					}
+					ox = (float) (iax / ibx);
+					oy = (float) (iay / ibx);
 					oc64data[it.oIndex] = ox;
 					oc64data[it.oIndex + 1] = oy;
 				}
@@ -10606,28 +10384,10 @@ public class Maths {
 						while (it.hasNext()) {
 							final double iax = it.aDouble;
 							final double ibx = it.bDouble;
-							final double iby = 0;
 							double ox;
 							double oy;
-							double q;
-							double den;
-							if (iby == 0) {
-								ox = (iax / ibx);
-								oy = (iay / ibx);
-							} else if (ibx == 0) {
-								ox = (iay / iby);
-								oy = (-iax / iby);
-							} else if (Math.abs(ibx) < Math.abs(iby)) {
-								q = (ibx / iby);
-								den = (ibx * q + iby);
-								ox = ((iax * q + iay) / den);
-								oy = ((iay * q - ibx) / den);
-							} else {
-								q = (iby / ibx);
-								den = (iby * q + ibx);
-								ox = ((iay * q + iax) / den);
-								oy = ((iay - iax * q) / den);
-							}
+							ox = (iax / ibx);
+							oy = (iay / ibx);
 							oc128data[it.oIndex] = ox;
 							oc128data[it.oIndex + 1] = oy;
 						}
@@ -10637,59 +10397,23 @@ public class Maths {
 					while (it.hasNext()) {
 						final long iax = it.aLong;
 						final long ibx = it.bLong;
-						final long iby = 0;
 						double ox;
 						double oy;
-						double q;
-						double den;
-						if (iby == 0) {
-							ox = (iax / ibx);
-							oy = (iay / ibx);
-						} else if (ibx == 0) {
-							ox = (iay / iby);
-							oy = (-iax / iby);
-						} else if (Math.abs(ibx) < Math.abs(iby)) {
-							q = (ibx / iby);
-							den = (ibx * q + iby);
-							ox = ((iax * q + iay) / den);
-							oy = ((iay * q - ibx) / den);
-						} else {
-							q = (iby / ibx);
-							den = (iby * q + ibx);
-							ox = ((iay * q + iax) / den);
-							oy = ((iay - iax * q) / den);
-						}
+						ox = (iax / ibx);
+						oy = (iay / ibx);
 						oc128data[it.oIndex] = ox;
 						oc128data[it.oIndex + 1] = oy;
 					}
 				}
 			} else if (!db.isComplex()) {
-				final double iby = 0;
 				while (it.hasNext()) {
 					final double iax = it.aDouble;
 					final double ibx = it.bDouble;
 					final double iay = da.getElementDoubleAbs(it.aIndex + 1);
 					double ox;
 					double oy;
-					double q;
-					double den;
-					if (iby == 0) {
-						ox = (iax / ibx);
-						oy = (iay / ibx);
-					} else if (ibx == 0) {
-						ox = (iay / iby);
-						oy = (-iax / iby);
-					} else if (Math.abs(ibx) < Math.abs(iby)) {
-						q = (ibx / iby);
-						den = (ibx * q + iby);
-						ox = ((iax * q + iay) / den);
-						oy = ((iay * q - ibx) / den);
-					} else {
-						q = (iby / ibx);
-						den = (iby * q + ibx);
-						ox = ((iay * q + iax) / den);
-						oy = ((iay - iax * q) / den);
-					}
+					ox = (iax / ibx);
+					oy = (iay / ibx);
 					oc128data[it.oIndex] = ox;
 					oc128data[it.oIndex + 1] = oy;
 				}

--- a/org.eclipse.january/src/org/eclipse/january/dataset/NullIterator.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/NullIterator.java
@@ -10,6 +10,13 @@
 package org.eclipse.january.dataset;
 
 public class NullIterator extends SliceIterator {
+
+	/**
+	 * @since 2.3
+	 */
+	public NullIterator() {
+	}
+
 	/**
 	 * @param shape shape of dataset
 	 * @param sshape shape of slice

--- a/org.eclipse.january/src/org/eclipse/january/dataset/ObjectDatasetBase.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/ObjectDatasetBase.java
@@ -21,6 +21,8 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import org.eclipse.january.metadata.StatisticsMetadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -29,6 +31,8 @@ import org.eclipse.january.metadata.StatisticsMetadata;
 public class ObjectDatasetBase extends AbstractDataset {
 	// pin UID to base class
 	private static final long serialVersionUID = Dataset.serialVersionUID;
+
+	private static final Logger logger = LoggerFactory.getLogger(ObjectDatasetBase.class);
 
 	protected Object[] data; // subclass alias // PRIM_TYPE
 

--- a/org.eclipse.january/src/org/eclipse/january/dataset/ObjectDatasetBase.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/ObjectDatasetBase.java
@@ -51,11 +51,6 @@ public class ObjectDatasetBase extends AbstractDataset {
 		return array;
 	}
 
-	@Override
-	public int getDType() {
-		return OBJECT; // DATA_TYPE
-	}
-
 	/**
 	 * Create a null dataset
 	 */

--- a/org.eclipse.january/src/org/eclipse/january/dataset/PositionIterator.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/PositionIterator.java
@@ -121,11 +121,17 @@ public class PositionIterator extends IndexIterator {
 				throw new UnsupportedOperationException("Negative steps not implemented");
 			}
 		}
-		int rank = oshape.length;
+		int rank;
+		if (oshape == null) {
+			rank = 0;
+			shape = null;
+		} else {
+			rank = oshape.length;
+			shape = oshape.clone();
+		}
 		endrank = rank - 1;
 
 		omit = new boolean[rank];
-		shape = oshape.clone();
 		if (axes != null) {
 			for (int a : axes) {
 				a = ShapeUtils.checkAxis(rank, a);

--- a/org.eclipse.january/src/org/eclipse/january/dataset/RGBDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/RGBDataset.java
@@ -184,8 +184,8 @@ public class RGBDataset extends CompoundShortDataset implements Cloneable {
 
 		for (int i = 0; riter.hasNext() && giter.hasNext() && biter.hasNext();) {
 			data[i++] = (short) red.getElementLongAbs(riter.index);
-			data[i++] = (short) green.getElementLongAbs(riter.index);
-			data[i++] = (short) blue.getElementLongAbs(riter.index);
+			data[i++] = (short) green.getElementLongAbs(giter.index);
+			data[i++] = (short) blue.getElementLongAbs(biter.index);
 		}
 	}
 

--- a/org.eclipse.january/src/org/eclipse/january/dataset/RGBDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/RGBDataset.java
@@ -14,12 +14,17 @@ package org.eclipse.january.dataset;
 
 import java.util.Arrays;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Class to hold colour datasets as red, green, blue tuples of short integers
  */
 public class RGBDataset extends CompoundShortDataset implements Cloneable {
 	// pin UID to base class
 	private static final long serialVersionUID = Dataset.serialVersionUID;
+
+	private static final Logger logger = LoggerFactory.getLogger(RGBDataset.class);
 
 	private static final int ISIZE = 3; // number of elements per item
 

--- a/org.eclipse.january/src/org/eclipse/january/dataset/RGBDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/RGBDataset.java
@@ -23,11 +23,6 @@ public class RGBDataset extends CompoundShortDataset implements Cloneable {
 
 	private static final int ISIZE = 3; // number of elements per item
 
-	@Override
-	public int getDType() {
-		return Dataset.RGB;
-	}
-
 	/**
 	 * Create a null dataset
 	 */
@@ -562,7 +557,7 @@ public class RGBDataset extends CompoundShortDataset implements Cloneable {
 	 * @since 2.2
 	 */
 	public <T extends Dataset> T createGreyDataset(final Class<T> clazz) {
-		return (T) createGreyDataset(clazz, Wr, Wg, Wb);
+		return createGreyDataset(clazz, Wr, Wg, Wb);
 	}
 
 	/**
@@ -574,9 +569,15 @@ public class RGBDataset extends CompoundShortDataset implements Cloneable {
 	 * @return a grey-scale dataset of given class
 	 * @since 2.2
 	 */
-	@SuppressWarnings("unchecked")
 	public <T extends Dataset> T createGreyDataset(final Class<T> clazz, final double red, final double green, final double blue) {
-		return (T) createGreyDataset(red, green, blue, DTypeUtils.getDType(clazz));
+		final T grey = DatasetFactory.zeros(clazz, shape);
+		final IndexIterator it = getIterator();
+
+		int i = 0;
+		while (it.hasNext()) {
+			grey.setObjectAbs(i++, red*data[it.index] + green*data[it.index + 1] + blue*data[it.index + 2]);
+		}
+		return grey;
 	}
 
 	/**
@@ -601,14 +602,7 @@ public class RGBDataset extends CompoundShortDataset implements Cloneable {
 	 */
 	@Deprecated
 	public Dataset createGreyDataset(final double red, final double green, final double blue, final int dtype) {
-		final Dataset grey = DatasetFactory.zeros(shape, dtype);
-		final IndexIterator it = getIterator();
-
-		int i = 0;
-		while (it.hasNext()) {
-			grey.setObjectAbs(i++, red*data[it.index] + green*data[it.index + 1] + blue*data[it.index + 2]);
-		}
-		return grey;
+		return createGreyDataset(DTypeUtils.getInterface(dtype), red, green, blue);
 	}
 
 	/**
@@ -617,7 +611,7 @@ public class RGBDataset extends CompoundShortDataset implements Cloneable {
 	 * @return a dataset of given class
 	 * @since 2.1
 	 */
-	public <T extends Dataset> T createRedDataset(final T clazz) {
+	public <T extends Dataset> T createRedDataset(final Class<T> clazz) {
 		return createColourChannelDataset(0, clazz, "red");
 	}
 
@@ -627,7 +621,7 @@ public class RGBDataset extends CompoundShortDataset implements Cloneable {
 	 * @return a dataset of given class
 	 * @since 2.1
 	 */
-	public <T extends Dataset> T createGreenDataset(final T clazz) {
+	public <T extends Dataset> T createGreenDataset(final Class<T> clazz) {
 		return createColourChannelDataset(1, clazz, "green");
 	}
 
@@ -637,7 +631,7 @@ public class RGBDataset extends CompoundShortDataset implements Cloneable {
 	 * @return a dataset of given class
 	 * @since 2.1
 	 */
-	public <T extends Dataset> T createBlueDataset(final T clazz) {
+	public <T extends Dataset> T createBlueDataset(final Class<T> clazz) {
 		return createColourChannelDataset(2, clazz, "blue");
 	}
 
@@ -649,7 +643,7 @@ public class RGBDataset extends CompoundShortDataset implements Cloneable {
 	 */
 	@Deprecated
 	public Dataset createRedDataset(final int dtype) {
-		return createColourChannelDataset(0, dtype, "red");
+		return createColourChannelDataset(0, DTypeUtils.getInterface(dtype), "red");
 	}
 
 	/**
@@ -660,7 +654,7 @@ public class RGBDataset extends CompoundShortDataset implements Cloneable {
 	 */
 	@Deprecated
 	public Dataset createGreenDataset(final int dtype) {
-		return createColourChannelDataset(1, dtype, "green");
+		return createColourChannelDataset(1, DTypeUtils.getInterface(dtype), "green");
 	}
 
 	/**
@@ -671,18 +665,11 @@ public class RGBDataset extends CompoundShortDataset implements Cloneable {
 	 */
 	@Deprecated
 	public Dataset createBlueDataset(final int dtype) {
-		return createColourChannelDataset(2, dtype, "blue");
+		return createColourChannelDataset(2, DTypeUtils.getInterface(dtype), "blue");
 	}
 
-	@SuppressWarnings("unchecked")
-	private <T extends Dataset> T createColourChannelDataset(int channelOffset, T clazz, String cName) {
-		return (T) createColourChannelDataset(channelOffset, DTypeUtils.getDType(clazz), cName);
-	}
-
-
-	@Deprecated
-	private Dataset createColourChannelDataset(final int channelOffset, final int dtype, final String cName) {
-		final Dataset channel = DatasetFactory.zeros(shape, dtype);
+	private <T extends Dataset> T createColourChannelDataset(int channelOffset, Class<T> clazz, String cName) {
+		final T channel = DatasetFactory.zeros(clazz, shape);
 
 		final StringBuilder cname = name == null ? new StringBuilder() : new StringBuilder(name);
 		if (cname.length() > 0) {
@@ -700,6 +687,7 @@ public class RGBDataset extends CompoundShortDataset implements Cloneable {
 
 		return channel;
 	}
+
 
 	/**
 	 * @return red view

--- a/org.eclipse.january/src/org/eclipse/january/dataset/Random.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/Random.java
@@ -188,7 +188,7 @@ public class Random {
 	 * @return a lazy dataset with uniformly distributed random numbers
 	 */
 	public static ILazyDataset lazyRand(int... shape) {
-		return lazyRand(Dataset.FLOAT64, "random", shape);
+		return lazyRand("random", DoubleDataset.class, shape);
 	}
 
 	/**
@@ -197,7 +197,7 @@ public class Random {
 	 * @return a lazy dataset with uniformly distributed random numbers
 	 */
 	public static ILazyDataset lazyRand(String name, int... shape) {
-		return lazyRand(Dataset.FLOAT64, name, shape);
+		return lazyRand(name, DoubleDataset.class, shape);
 	}
 
 	/**
@@ -205,10 +205,23 @@ public class Random {
 	 * @param name
 	 * @param shape
 	 * @return a lazy dataset with uniformly distributed random numbers
+	 * @deprecated Use {@link #lazyRand(String, Class, int...)}
 	 */
+	@Deprecated
 	public static ILazyDataset lazyRand(int dtype, String name, int... shape) {
+		return lazyRand(name, DTypeUtils.getInterface(dtype), shape);
+	}
+
+	/**
+	 * @param name
+	 * @param clazz dataset interface
+	 * @param shape
+	 * @return a lazy dataset with uniformly distributed random numbers
+	 * @since 2.3
+	 */
+	public static ILazyDataset lazyRand(String name, final Class<? extends Dataset> clazz, int... shape) {
 		
-		return new LazyDataset(name, dtype, shape, new ILazyLoader() {
+		return new LazyDataset(new ILazyLoader() {
 			private static final long serialVersionUID = ILazyLoader.serialVersionUID;
 
 			@Override
@@ -218,8 +231,9 @@ public class Random {
 
 			@Override
 			public IDataset getDataset(IMonitor mon, SliceND slice) throws IOException {
-				return rand(slice.getShape());
+				return rand(slice.getShape()).cast(clazz);
 			}
-		});
+		},
+		name, clazz, shape);
 	}
 }

--- a/org.eclipse.january/src/org/eclipse/january/dataset/ShortDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/ShortDataset.java
@@ -52,11 +52,6 @@ public class ShortDataset extends AbstractDataset {
 		return array;
 	}
 
-	@Override
-	public int getDType() {
-		return INT16; // DATA_TYPE
-	}
-
 	/**
 	 * Create a null dataset
 	 */

--- a/org.eclipse.january/src/org/eclipse/january/dataset/ShortDataset.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/ShortDataset.java
@@ -22,6 +22,8 @@ import java.util.TreeSet;
 
 import org.apache.commons.math3.complex.Complex;
 import org.eclipse.january.metadata.StatisticsMetadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -30,6 +32,8 @@ import org.eclipse.january.metadata.StatisticsMetadata;
 public class ShortDataset extends AbstractDataset {
 	// pin UID to base class
 	private static final long serialVersionUID = Dataset.serialVersionUID;
+
+	private static final Logger logger = LoggerFactory.getLogger(ShortDataset.class);
 
 	protected short[] data; // subclass alias // PRIM_TYPE
 

--- a/org.eclipse.january/src/org/eclipse/january/dataset/Slice.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/Slice.java
@@ -331,7 +331,7 @@ public class Slice implements Cloneable, Serializable {
 	}
 
 	/**
-	 * Appends a String representation of the Slice comparable to the python
+	 * Append a string representation of the Slice comparable to the Python
 	 * representation.
 	 * 
 	 * @param s
@@ -381,7 +381,7 @@ public class Slice implements Cloneable, Serializable {
 	}
 
 	/**
-	 * Returns a string construction of the slice with the python form.
+	 * Returns a string construction of the slice with the Python form.
 	 * 
 	 * @return Constructed String.
 	 */
@@ -578,6 +578,8 @@ public class Slice implements Cloneable, Serializable {
 		return slice;
 	}
 
+	private static final int COLON = ':';
+
 	/**
 	 * Converts string in a Slice array
 	 * 
@@ -599,7 +601,7 @@ public class Slice implements Cloneable, Serializable {
 			Slice slice = new Slice();
 			slices[i] = slice;
 
-			int idx0 = s.indexOf(":");
+			int idx0 = s.indexOf(COLON);
 
 			int n = 0;
 			if (idx0 == -1) {
@@ -613,11 +615,12 @@ public class Slice implements Cloneable, Serializable {
 			slice.setStart(n);
 
 			idx0++;
-			int idx1 = s.indexOf(":", idx0);
+			int idx1 = s.indexOf(COLON, idx0);
 			if (idx1 == -1) {
 				String t = s.substring(idx0).trim();
-				if (t.length() == 0)
+				if (t.length() == 0) {
 					continue;
+				}
 
 				slice.setStop(Integer.parseInt(t));
 				continue;
@@ -626,8 +629,9 @@ public class Slice implements Cloneable, Serializable {
 			}
 
 			String t = s.substring(idx1 + 1).trim();
-			if (t.length() > 0)
+			if (t.length() > 0) {
 				slice.setStep(Integer.parseInt(t));
+			}
 		}
 
 		return slices;

--- a/org.eclipse.january/src/org/eclipse/january/dataset/SliceIterator.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/SliceIterator.java
@@ -177,7 +177,7 @@ public class SliceIterator extends IndexIterator {
 	public SliceIterator(final int[] shape, final int length, final int[] start, final int[] step, final int[] sshape,
 			final int isize) {
 		this.isize = isize;
-		int rank = shape.length;
+		final int rank = shape == null ? 0 : shape.length;
 		endrank = rank - 1;
 		this.shape = shape;
 		this.start = new int[rank];
@@ -232,7 +232,7 @@ public class SliceIterator extends IndexIterator {
 	 *            may be {@code null}
 	 */
 	public void setStart(int... newStart) {
-		final int rank = shape.length;
+		final int rank = shape == null ? 0 : shape.length;
 		if (rank == 0) {
 			index = -istep;
 			return;
@@ -263,7 +263,8 @@ public class SliceIterator extends IndexIterator {
 	 */
 	@Override
 	public void reset() {
-		if (shape.length == 0) {
+		final int rank = shape == null ? 0 : shape.length;
+		if (rank == 0) {
 			index = -istep;
 		} else {
 			// work out index of first position

--- a/org.eclipse.january/src/org/eclipse/january/dataset/SliceND.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/SliceND.java
@@ -28,6 +28,10 @@ public class SliceND {
 
 	private boolean expanded;
 
+	private static int[] copy(int[] in) {
+		return in == null ? null : in.clone();
+	}
+
 	/**
 	 * Construct a nD Slice for whole of shape.
 	 * 
@@ -35,13 +39,13 @@ public class SliceND {
 	 *            Shape of the dataset, see {@link ILazyDataset#getShape()}
 	 */
 	public SliceND(final int[] shape) {
-		final int rank = shape.length;
+		final int rank = shape == null ? 0 : shape.length;
 		lstart = new int[rank];
-		lstop = shape.clone();
+		lstop = copy(shape);
 		lstep = new int[rank];
 		Arrays.fill(lstep, 1);
-		lshape = shape.clone();
-		oshape = shape.clone();
+		lshape = copy(shape);
+		oshape = copy(shape);
 		mshape = oshape;
 		expanded = false;
 	}
@@ -148,8 +152,7 @@ public class SliceND {
 		//
 		// thus the final index in each dimension is
 		// start + (shape-1)*step
-
-		int rank = shape.length;
+		final int rank = shape == null ? 0 : shape.length;
 
 		if (start == null) {
 			lstart = new int[rank];
@@ -174,7 +177,7 @@ public class SliceND {
 		}
 
 		lshape = new int[rank];
-		oshape = shape.clone();
+		oshape = copy(shape);
 		if (maxShape == null) {
 			mshape = oshape;
 		} else {
@@ -505,11 +508,13 @@ public class SliceND {
 	@Override
 	public SliceND clone() {
 		SliceND c = new SliceND(oshape);
-		for (int i = 0; i < lshape.length; i++) {
-			c.lstart[i] = lstart[i];
-			c.lstop[i] = lstop[i];
-			c.lstep[i] = lstep[i];
-			c.lshape[i] = lshape[i];
+		if (lshape != null) {
+			for (int i = 0; i < lshape.length; i++) {
+				c.lstart[i] = lstart[i];
+				c.lstop[i] = lstop[i];
+				c.lstep[i] = lstep[i];
+				c.lshape[i] = lshape[i];
+			}
 		}
 		c.expanded = expanded;
 		return c;

--- a/org.eclipse.january/src/org/eclipse/january/dataset/SliceNDIterator.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/SliceNDIterator.java
@@ -55,7 +55,7 @@ public class SliceNDIterator extends IndexIterator {
 	public SliceNDIterator(SliceND slice, int... axes) {
 		cSlice = slice.clone();
 		int[] sShape = cSlice.getSourceShape();
-		shape = cSlice.getShape().clone();
+		shape = sShape == null ? null : cSlice.getShape().clone();
 		start = cSlice.getStart();
 		stop  = cSlice.getStop();
 		step  = cSlice.getStep();
@@ -64,7 +64,7 @@ public class SliceNDIterator extends IndexIterator {
 				throw new UnsupportedOperationException("Negative steps not implemented");
 			}
 		}
-		int rank = shape.length;
+		final int rank = shape == null ? 0 : shape.length;
 		endrank = rank - 1;
 
 		omit = new boolean[rank];
@@ -214,6 +214,7 @@ public class SliceNDIterator extends IndexIterator {
 
 	@Override
 	public void reset() {
+		once = false;
 		for (int i = 0, k = 0; i <= endrank; i++) {
 			int b = start[i];
 			int d = step[i];
@@ -235,7 +236,7 @@ public class SliceNDIterator extends IndexIterator {
 				break;
 		}
 		if (j > endrank) {
-			once = true;
+			once = shape != null;
 			return;
 		}
 

--- a/org.eclipse.january/src/org/eclipse/january/dataset/SliceNDIterator.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/SliceNDIterator.java
@@ -93,6 +93,10 @@ public class SliceNDIterator extends IndexIterator {
 			sStop = null;
 			iSlice = null;
 			sSlice = cSlice;
+			int[] dShape = dSlice.getShape();
+			for (int i = 0; i < rank; i++) {
+				dShape[i] = 1;
+			}
 		} else {
 			int[] dShape = dSlice.getShape();
 			int[] oShape = new int[sRank]; // outer shape

--- a/org.eclipse.january/src/org/eclipse/january/dataset/StrideIterator.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/StrideIterator.java
@@ -46,7 +46,7 @@ public class StrideIterator extends SliceIterator {
 	}
 
 	public StrideIterator(final int isize, final int[] shape, final int[] strides, final int offset, final int element) {
-		int rank = shape.length;
+		final int rank = shape == null ? 0 : shape.length;
 		start = new int[rank];
 		stop = shape;
 		step = new int[rank];
@@ -79,7 +79,8 @@ public class StrideIterator extends SliceIterator {
 		this.isize = isize;
 		istep = isize;
 		this.shape = shape;
-		int rank = shape.length;
+		final int rank = shape == null ? 0 : shape.length;
+		zero = shape == null;
 		endrank = rank - 1;
 		pos = new int[rank];
 		delta = new int[rank];

--- a/org.eclipse.january/src/org/eclipse/january/dataset/StringDatasetBase.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/StringDatasetBase.java
@@ -51,11 +51,6 @@ public class StringDatasetBase extends AbstractDataset {
 		return array;
 	}
 
-	@Override
-	public int getDType() {
-		return STRING; // DATA_TYPE
-	}
-
 	/**
 	 * Create a null dataset
 	 */

--- a/org.eclipse.january/src/org/eclipse/january/dataset/StringDatasetBase.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/StringDatasetBase.java
@@ -21,6 +21,8 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import org.eclipse.january.metadata.StatisticsMetadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -29,6 +31,8 @@ import org.eclipse.january.metadata.StatisticsMetadata;
 public class StringDatasetBase extends AbstractDataset {
 	// pin UID to base class
 	private static final long serialVersionUID = Dataset.serialVersionUID;
+
+	private static final Logger logger = LoggerFactory.getLogger(StringDatasetBase.class);
 
 	protected String[] data; // subclass alias // PRIM_TYPE
 

--- a/org.eclipse.january/src/org/eclipse/january/dataset/internal/template/MathsPreface.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/internal/template/MathsPreface.java
@@ -2723,51 +2723,37 @@ class MathsPreface {
 		return ds;
 	}
 
-	private static double SelectedMean(Dataset data, int Min, int Max) {
-
+	private static double selectedMean(Dataset data, int min, int max) {
 		double result = 0.0;
-		for (int i = Min, imax = data.getSize(); i <= Max; i++) {
+		for (int i = min, end = data.getSize() - 1; i <= max; i++) {
 			// clip i appropriately, imagine that effectively the two ends
-			// continue
-			// straight out.
-			int pos = i;
-			if (pos < 0) {
-				pos = 0;
-			} else if (pos >= imax) {
-				pos = imax - 1;
-			}
-			result += data.getElementDoubleAbs(pos);
+			// continue straight out.
+			int pos = Math.min(Math.max(0, i), end);
+			result += data.getDouble(pos);
 		}
 
 		// now the sum is complete, average the values.
-		result /= (Max - Min) + 1;
+		result /= (max - min) + 1;
 		return result;
 	}
 
-	private static void SelectedMeanArray(double[] out, Dataset data, int Min, int Max) {
+	private static void selectedMeanArray(double[] out, Dataset data, int min, int max) {
+		Arrays.fill(out, 0);
 		final int isize = out.length;
-		for (int j = 0; j < isize; j++)
-			out[j] = 0.;
-
-		for (int i = Min, imax = data.getSize(); i <= Max; i++) {
+		for (int i = min, end = data.getSize() - 1; i <= max; i++) {
 			// clip i appropriately, imagine that effectively the two ends
-			// continue
-			// straight out.
-			int pos = i * isize;
-			if (pos < 0) {
-				pos = 0;
-			} else if (pos >= imax) {
-				pos = imax - isize;
+			// continue straight out.
+			int off = data.get1DIndex(Math.min(Math.max(0, i), end));
+			for (int j = 0; j < isize; j++) {
+				out[j] += data.getElementDoubleAbs(off++);
 			}
-			for (int j = 0; j < isize; j++)
-				out[j] += data.getElementDoubleAbs(pos + j);
 		}
 
 		// now the sum is complete, average the values.
-		double norm = 1. / (Max - Min + 1.);
-		for (int j = 0; j < isize; j++)
+		double norm = 1. / (max - min + 1.);
+		for (int j = 0; j < isize; j++) {
 			out[j] *= norm;
-
+		}
 	}
 
 	/**
@@ -2821,10 +2807,10 @@ class MathsPreface {
 		final int isize = y.getElementsPerItem();
 		if (isize == 1) {
 			for (int i = 0, imax = x.getSize(); i < imax; i++) {
-				double LeftValue = SelectedMean(y, i - n, i - 1);
-				double RightValue = SelectedMean(y, i + 1, i + n);
-				double LeftPosition = SelectedMean(x, i - n, i - 1);
-				double RightPosition = SelectedMean(x, i + 1, i + n);
+				double LeftValue = selectedMean(y, i - n, i - 1);
+				double RightValue = selectedMean(y, i + 1, i + n);
+				double LeftPosition = selectedMean(x, i - n, i - 1);
+				double RightPosition = selectedMean(x, i + 1, i + n);
 
 				// now the values and positions are calculated, the derivative
 				// can be
@@ -2835,10 +2821,10 @@ class MathsPreface {
 			double[] leftValues = new double[isize];
 			double[] rightValues = new double[isize];
 			for (int i = 0, imax = x.getSize(); i < imax; i++) {
-				SelectedMeanArray(leftValues, y, i - n, i - 1);
-				SelectedMeanArray(rightValues, y, i + 1, i + n);
-				double delta = SelectedMean(x, i - n, i - 1);
-				delta = 1. / (SelectedMean(x, i + 1, i + n) - delta);
+				selectedMeanArray(leftValues, y, i - n, i - 1);
+				selectedMeanArray(rightValues, y, i + 1, i + n);
+				double delta = selectedMean(x, i - n, i - 1);
+				delta = 1. / (selectedMean(x, i + 1, i + n) - delta);
 				for (int j = 0; j < isize; j++) {
 					rightValues[j] -= leftValues[j];
 					rightValues[j] *= delta;

--- a/org.eclipse.january/src/org/eclipse/january/dataset/internal/template/fromcpddouble.py
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/internal/template/fromcpddouble.py
@@ -43,8 +43,8 @@ allds = {
  }
 
 def generateclass(dclass):
-    handlers  = [ transmutate(__file__, defkey, defds[defkey], d, fds[d], True, isatomic=False) for d in fds ]
-    handlers += [ transmutate(__file__, defkey, defds[defkey], d, allds[d], False, isatomic=False) for d in allds ]
+    handlers  = [ transmutate(__file__, defkey, defds[defkey], d, fds[d], True) for d in fds ]
+    handlers += [ transmutate(__file__, defkey, defds[defkey], d, allds[d], False) for d in allds ]
     files  = [ open(d + ".java", "w") for d in fds ]
     files += [ open(d + ".java", "w") for d in allds ]
     ncls = len(files)

--- a/org.eclipse.january/src/org/eclipse/january/dataset/internal/template/functions.txt
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/internal/template/functions.txt
@@ -52,6 +52,9 @@ complex:
   	ox = (iay * q + iax) / den;
   	oy = (iay - iax * q) / den;
   }
+complex_b_real;
+  ox = iax / ibx;
+  oy = iay / ibx;
 
 biop:
   dividez - a / b, division of a by b
@@ -73,6 +76,14 @@ complex:
   	den = iby * q + ibx;
   	ox = (iay * q + iax) / den;
   	oy = (iay - iax * q) / den;
+  }
+complex_b_real;
+  if (ibx == 0) {
+  	ox = 0;
+  	oy = 0;
+  } else {
+  	ox = iax / ibx;
+  	oy = iay / ibx;
   }
 
 biop:
@@ -106,6 +117,9 @@ complex:
   	ox = (iay * q + iax) / den;
   	oy = (iay - iax * q) / den;
   }
+complex_b_real;
+  ox = iax / ibx;
+  oy = iay / ibx;
 
 biop:
   power - a ** b, raise a to power of b

--- a/org.eclipse.january/src/org/eclipse/january/dataset/internal/template/functions.txt
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/internal/template/functions.txt
@@ -45,7 +45,7 @@ complex:
   	q = ibx / iby;
   	den = ibx * q + iby;
   	ox = (iax * q + iay) / den;
-  	oy = (iay * q - ibx) / den;
+  	oy = (iay * q - iax) / den;
   } else {
   	q = iby / ibx;
   	den = iby * q + ibx;
@@ -70,7 +70,7 @@ complex:
   	q = ibx / iby;
   	den = ibx * q + iby;
   	ox = (iax * q + iay) / den;
-  	oy = (iay * q - ibx) / den;
+  	oy = (iay * q - iax) / den;
   } else {
   	q = iby / ibx;
   	den = iby * q + ibx;
@@ -110,7 +110,7 @@ complex:
   	q = ibx / iby;
   	den = ibx * q + iby;
   	ox = (iax * q + iay) / den;
-  	oy = (iay * q - ibx) / den;
+  	oy = (iay * q - iax) / den;
   } else {
   	q = iby / ibx;
   	den = iby * q + ibx;

--- a/org.eclipse.january/src/org/eclipse/january/dataset/internal/template/markers.py
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/internal/template/markers.py
@@ -50,7 +50,7 @@ Mark up source class with following comment markers:
 
 class transmutate(object):
     def __init__(self, scriptfile, srcclass, source, dstclass, destination, disreal=True,
-                 disbool=False, disobj=False, isatomic=True):
+                 disbool=False, disobj=False):
         '''
         scriptfile
         srcclass
@@ -60,7 +60,6 @@ class transmutate(object):
         disreal indicates whether destination is a real dataset
         disbool indicates whether destination is a boolean dataset
         disobj indicates whether destination is an object type-dataset
-        isatomic indicates whether dataset is atomic or compound
 
         source and destination are lists of strings which describe dtype,
         Java boxed primitive class, Java primitive type, getElement abstract method,
@@ -91,15 +90,10 @@ class transmutate(object):
         self.isreal = disreal
         self.isbool = disbool
         self.isobj = disobj
-        self.isatomic = isatomic
         if self.isbool:
             self.isreal = False
-        if not self.isatomic: # make compound dataset types
-            self.scdtype = "ARRAY" + self.sdtype
-            self.dcdtype = "ARRAY" + self.ddtype
 
-        processors = [("// DATA_TYPE", self.data),
-            ("// CLASS_TYPE", self.jpclass),
+        processors = [ ("// CLASS_TYPE", self.jpclass),
             ("// PRIM_TYPE", self.primitive),
             ("// ADD_CAST", self.addcast),
             ("// PRIM_TYPE_LONG", self.primitivelong),
@@ -125,7 +119,7 @@ class transmutate(object):
             ("// DEFAULT_VAL", self.defval),
             ("// BCAST_WITH_CAST", self.broadcast),
             ("@SuppressWarnings(\"cast\")", self.omit),
-            (srcclass, self.jclass)]
+            (srcclass, self.jclass) ]
 
         self.icasts = [ "(byte) ", "(short) ", "(int) ", "(long) "]
         self.rcasts = [ "(float) ", "(double) "]
@@ -143,15 +137,6 @@ class transmutate(object):
     # starts with _, $ and unicode letter and comprises Unicode letters and digits
     import re
     separator = re.compile(r'[\s(]')
-
-    def data(self, line):
-        '''
-        dataset type
-        '''
-        l = line.replace(self.sdtype, self.ddtype)
-        if not self.isatomic:
-            l = l.replace(self.scdtype, self.dcdtype)
-        return l
 
     def jclass(self, line):
         '''

--- a/org.eclipse.january/src/org/eclipse/january/metadata/internal/StatisticsMetadataImpl.java
+++ b/org.eclipse.january/src/org/eclipse/january/metadata/internal/StatisticsMetadataImpl.java
@@ -20,7 +20,6 @@ import java.util.Map;
 import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
 import org.eclipse.january.dataset.CompoundDataset;
 import org.eclipse.january.dataset.CompoundDoubleDataset;
-import org.eclipse.january.dataset.DTypeUtils;
 import org.eclipse.january.dataset.Dataset;
 import org.eclipse.january.dataset.DatasetFactory;
 import org.eclipse.january.dataset.DoubleDataset;
@@ -601,7 +600,7 @@ public class StatisticsMetadataImpl<T> implements StatisticsMetadata<T> {
 			min = DatasetFactory.zeros(clazz, nshape);
 			maxIndex = axes.length == 1 ? DatasetFactory.zeros(IntegerDataset.class, nshape) : null;
 			minIndex = axes.length == 1 ? DatasetFactory.zeros(IntegerDataset.class, nshape) : null;
-			sum = DatasetFactory.zeros(DTypeUtils.getLargestDataset(clazz), nshape);
+			sum = DatasetFactory.zeros(InterfaceUtils.getLargestInterface(dataset), nshape);
 			mean = DatasetFactory.zeros(DoubleDataset.class, nshape);
 			var = DatasetFactory.zeros(DoubleDataset.class, nshape);
 		} else {
@@ -609,7 +608,7 @@ public class StatisticsMetadataImpl<T> implements StatisticsMetadata<T> {
 			min = null;
 			maxIndex = null;
 			minIndex = null;
-			sum = DatasetFactory.zeros(isize, DTypeUtils.getLargestDataset(clazz), nshape);
+			sum = DatasetFactory.zeros(isize, InterfaceUtils.getLargestInterface(dataset), nshape);
 			mean = DatasetFactory.zeros(isize, CompoundDoubleDataset.class, nshape);
 			var = DatasetFactory.zeros(isize, CompoundDoubleDataset.class, nshape);
 		}

--- a/org.eclipse.january/src/org/eclipse/january/metadata/internal/StatisticsMetadataImpl.java
+++ b/org.eclipse.january/src/org/eclipse/january/metadata/internal/StatisticsMetadataImpl.java
@@ -107,7 +107,7 @@ public class StatisticsMetadataImpl<T> implements StatisticsMetadata<T> {
 		this.dataset = dataset.getView(false);
 		this.dataset.clearMetadata(null);
 		isFloat = dataset.hasFloatingPointElements();
-		clazz = dataset.getClass();
+		clazz = InterfaceUtils.getLargestInterface(dataset);
 		isize = dataset.getElementsPerItem();
 		mms = new MaxMin[COMBOS];
 		summaries = new SummaryStatistics[COMBOS][];

--- a/org.eclipse.january/src/org/eclipse/january/metadata/internal/StatisticsMetadataImpl.java
+++ b/org.eclipse.january/src/org/eclipse/january/metadata/internal/StatisticsMetadataImpl.java
@@ -166,6 +166,15 @@ public class StatisticsMetadataImpl<T> implements StatisticsMetadata<T> {
 	 */
 	@SuppressWarnings("unchecked")
 	private void setMaxMinSum(final MaxMin<T> mm, final boolean ignoreNaNs, final boolean ignoreInfs) {
+		if (dataset.getSize() == 0) {
+			mm.maximum = null;
+			mm.minimum = null;
+			mm.sum = (T) (isize == 1 ? InterfaceUtils.fromDoubleToBiggestNumber(clazz, 0) : null);
+			mm.maximumPositions = null;
+			mm.minimumPositions = null;
+			return;
+		}
+
 		final IndexIterator iter = dataset.getIterator();
 
 		if (!InterfaceUtils.isNumerical(clazz)) { // TODO FIXME for strings
@@ -431,7 +440,11 @@ public class StatisticsMetadataImpl<T> implements StatisticsMetadata<T> {
 	@Override
 	public T getMaximum(boolean... ignoreInvalids) {
 		int idx = refresh(isize == 1, ignoreInvalids);
-		return mms[idx].maximum;
+		T t = mms[idx].maximum;
+		if (t == null) {
+			throw new UnsupportedOperationException("Cannot operate on zero-sized dataset");
+		}
+		return t;
 	}
 
 	@Override
@@ -465,7 +478,11 @@ public class StatisticsMetadataImpl<T> implements StatisticsMetadata<T> {
 	@Override
 	public T getMinimum(boolean... ignoreInvalids) {
 		int idx = refresh(isize == 1, ignoreInvalids);
-		return mms[idx].minimum;
+		T t = mms[idx].minimum;
+		if (t == null) {
+			throw new UnsupportedOperationException("Cannot operate on zero-sized dataset");
+		}
+		return t;
 	}
 
 	@Override

--- a/org.eclipse.january/src/org/eclipse/january/metadata/internal/StatisticsMetadataImpl.java
+++ b/org.eclipse.january/src/org/eclipse/january/metadata/internal/StatisticsMetadataImpl.java
@@ -152,6 +152,13 @@ public class StatisticsMetadataImpl<T> implements StatisticsMetadata<T> {
 		return idx;
 	}
 
+	private Number toNumber(double x) {
+		if (dataset != null) {
+			return InterfaceUtils.fromDoubleToNumber(dataset.getClass(), x);
+		}
+		return Double.valueOf(x);
+	}
+
 	/**
 	 * Calculate summary statistics for a dataset
 	 * @param mm
@@ -242,8 +249,8 @@ public class StatisticsMetadataImpl<T> implements StatisticsMetadata<T> {
 				}
 			}
 
-			mm.maximum = (T) (hasNaNs ? Double.NaN : InterfaceUtils.fromDoubleToBiggestNumber(clazz, amax));
-			mm.minimum = (T) (hasNaNs ? Double.NaN : InterfaceUtils.fromDoubleToBiggestNumber(clazz, amin));
+			mm.maximum = (T) (hasNaNs ? Double.NaN : toNumber(amax));
+			mm.minimum = (T) (hasNaNs ? Double.NaN : toNumber(amin));
 			mm.sum     = (T) (hasNaNs ? Double.NaN : InterfaceUtils.fromDoubleToBiggestNumber(clazz, asum));
 		} else {
 			while (iter.hasNext()) {
@@ -313,8 +320,8 @@ public class StatisticsMetadataImpl<T> implements StatisticsMetadata<T> {
 				}
 			}
 
-			mm.maximum = (T) (hasNaNs ? Double.NaN : InterfaceUtils.fromDoubleToBiggestNumber(clazz, stats.getMax()));
-			mm.minimum = (T) (hasNaNs ? Double.NaN : InterfaceUtils.fromDoubleToBiggestNumber(clazz, stats.getMin()));
+			mm.maximum = (T) (hasNaNs ? Double.NaN : toNumber(stats.getMax()));
+			mm.minimum = (T) (hasNaNs ? Double.NaN : toNumber(stats.getMin()));
 			mm.sum     = (T) (hasNaNs ? Double.NaN : InterfaceUtils.fromDoubleToBiggestNumber(clazz, stats.getSum()));
 		} else {
 			double[] vals = new double[isize];

--- a/org.eclipse.january/src/org/eclipse/january/metadata/internal/StatisticsMetadataImpl.java
+++ b/org.eclipse.january/src/org/eclipse/january/metadata/internal/StatisticsMetadataImpl.java
@@ -55,7 +55,6 @@ public class StatisticsMetadataImpl<T> implements StatisticsMetadata<T> {
 	private MaxMin<T>[] mms;
 	private SummaryStatistics[][] summaries;
 
-	
 	@Dirtiable
 	private boolean isDirty = true;
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,9 +27,6 @@
 		<developerConnection>scm:git:git@github.com:eclipse/january.git</developerConnection>
 		<url>https://github.com/eclipse/january.git</url>
 	</scm>
-	<prerequisites>
-		<maven>3.0</maven>
-	</prerequisites>
 
 	<name>The Eclipse January Project</name>
 	<description>Common data structures for Science</description>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.eclipse.january</groupId>
 	<artifactId>org.eclipse.january.root</artifactId>
-	<version>2.3.0-SNAPSHOT</version>
+	<version>2.3.0</version>
 
 	<packaging>pom</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.eclipse.january</groupId>
 	<artifactId>org.eclipse.january.root</artifactId>
-	<version>2.3.0</version>
+	<version>2.3.1-SNAPSHOT</version>
 
 	<packaging>pom</packaging>
 

--- a/releng/org.eclipse.january.releng.p2/category.xml
+++ b/releng/org.eclipse.january.releng.p2/category.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <bundle id="org.eclipse.january" version="2.3.0">
+   <bundle id="org.eclipse.january" version="2.3.1.qualifier">
       <category name="january_datasets"/>
    </bundle>
-   <bundle id="org.eclipse.january.source" version="2.3.0">
+   <bundle id="org.eclipse.january.source" version="2.3.1.qualifier">
       <category name="january_datasets"/>
    </bundle>
-   <bundle id="org.eclipse.january.asserts" version="2.3.0">
+   <bundle id="org.eclipse.january.asserts" version="2.3.1.qualifier">
       <category name="january_datasets_test"/>
    </bundle>
-   <bundle id="org.eclipse.january.asserts.source" version="2.3.0">
+   <bundle id="org.eclipse.january.asserts.source" version="2.3.1.qualifier">
       <category name="january_datasets_test"/>
    </bundle>
-   <bundle id="org.eclipse.january.test" version="2.3.0">
+   <bundle id="org.eclipse.january.test" version="2.3.1.qualifier">
       <category name="january_datasets_test"/>
    </bundle>
-   <bundle id="org.eclipse.january.test.source" version="2.3.0">
+   <bundle id="org.eclipse.january.test.source" version="2.3.1.qualifier">
       <category name="january_datasets_test"/>
    </bundle>
    <category-def name="january_datasets" label="January Datasets"/>

--- a/releng/org.eclipse.january.releng.p2/category.xml
+++ b/releng/org.eclipse.january.releng.p2/category.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <bundle id="org.eclipse.january" version="2.3.0.qualifier">
+   <bundle id="org.eclipse.january" version="2.3.0">
       <category name="january_datasets"/>
    </bundle>
-   <bundle id="org.eclipse.january.source" version="2.3.0.qualifier">
+   <bundle id="org.eclipse.january.source" version="2.3.0">
       <category name="january_datasets"/>
    </bundle>
-   <bundle id="org.eclipse.january.asserts" version="2.3.0.qualifier">
+   <bundle id="org.eclipse.january.asserts" version="2.3.0">
       <category name="january_datasets_test"/>
    </bundle>
-   <bundle id="org.eclipse.january.asserts.source" version="2.3.0.qualifier">
+   <bundle id="org.eclipse.january.asserts.source" version="2.3.0">
       <category name="january_datasets_test"/>
    </bundle>
-   <bundle id="org.eclipse.january.test" version="2.3.0.qualifier">
+   <bundle id="org.eclipse.january.test" version="2.3.0">
       <category name="january_datasets_test"/>
    </bundle>
-   <bundle id="org.eclipse.january.test.source" version="2.3.0.qualifier">
+   <bundle id="org.eclipse.january.test.source" version="2.3.0">
       <category name="january_datasets_test"/>
    </bundle>
    <category-def name="january_datasets" label="January Datasets"/>

--- a/releng/org.eclipse.january.releng.p2/pom.xml
+++ b/releng/org.eclipse.january.releng.p2/pom.xml
@@ -18,7 +18,7 @@
 	<parent>
 		<groupId>org.eclipse.january</groupId>
 		<artifactId>org.eclipse.january.releng</artifactId>
-		<version>2.3.0-SNAPSHOT</version>
+		<version>2.3.0</version>
 		<relativePath>../org.eclipse.january.releng</relativePath>
 	</parent>
 </project>

--- a/releng/org.eclipse.january.releng.p2/pom.xml
+++ b/releng/org.eclipse.january.releng.p2/pom.xml
@@ -18,7 +18,7 @@
 	<parent>
 		<groupId>org.eclipse.january</groupId>
 		<artifactId>org.eclipse.january.releng</artifactId>
-		<version>2.3.0</version>
+		<version>2.3.1-SNAPSHOT</version>
 		<relativePath>../org.eclipse.january.releng</relativePath>
 	</parent>
 </project>

--- a/releng/org.eclipse.january.releng.target/january-baseline.target
+++ b/releng/org.eclipse.january.releng.target/january-baseline.target
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/mbarbero/fr.obeo.releng.targetplatform -->
-<target name="January-baseline" sequenceNumber="1561543382">
+<target name="January-baseline" sequenceNumber="1539764717">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.january" version="0.0.0"/>
-      <repository id="january-2.2" location="https://download.eclipse.org/january/releases/2.2/repository/"/>
+      <repository id="january-2.2" location="https://download.eclipse.org/january/releases/2.2.2/repository/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.slf4j.api" version="1.7.2.v20121108-1250"/>
+      <unit id="org.slf4j.api" version="1.7.10.v20170428-1633"/>
       <unit id="org.apache.commons.math3" version="3.5.0.v20160301-1110"/>
-      <repository id="eclipse-orbit-oxygen-sr1" location="https://download.eclipse.org/tools/orbit/downloads/drops/R20170818183741/repository"/>
+      <repository id="eclipse-orbit-photon" location="https://download.eclipse.org/tools/orbit/downloads/drops/R20180606145124/repository"/>
     </location>
   </locations>
 </target>

--- a/releng/org.eclipse.january.releng.target/january-baseline.tpd
+++ b/releng/org.eclipse.january.releng.target/january-baseline.tpd
@@ -11,15 +11,14 @@
  *******************************************************************************/
 target "January-baseline" with source requirements
 
-location "http://download.eclipse.org/january/releases/2.0.0/repository/" january-2.0 {
+location "https://download.eclipse.org/january/releases/2.2.2/repository/" january-2.2 {
 	org.eclipse.january lazy
 }
 
-location "http://download.eclipse.org/tools/orbit/downloads/drops/R20170818183741/repository" eclipse-orbit-oxygen-sr1 {
+location "https://download.eclipse.org/tools/orbit/downloads/drops/R20180606145124/repository" eclipse-orbit-photon {
 
 // The versions we point to in Orbit are the versions we have CQs approved for, please
 // raise CQ for items not in this list or version changes
 	org.slf4j.api [1.7.2,1.7.3) // CQ 11781
 	org.apache.commons.math3 [3.5.0,3.5.1) // CQ 11785
-
 }

--- a/releng/org.eclipse.january.releng.target/org.eclipse.january.releng.target.target
+++ b/releng/org.eclipse.january.releng.target/org.eclipse.january.releng.target.target
@@ -10,7 +10,6 @@
       <unit id="org.hamcrest.core" version="1.3.0.v20180420-1519"/>
       <unit id="org.hamcrest.library" version="1.3.0.v20180524-2246"/>
       <unit id="org.junit" version="4.12.0.v201504281640"/>
-      <unit id="org.mockito" version="1.9.5.v201605172210"/>
       <repository id="eclipse-orbit-photon" location="http://download.eclipse.org/tools/orbit/downloads/drops/R20180606145124/repository"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">

--- a/releng/org.eclipse.january.releng.target/org.eclipse.january.releng.target.target
+++ b/releng/org.eclipse.january.releng.target/org.eclipse.january.releng.target.target
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/mbarbero/fr.obeo.releng.targetplatform -->
-<target name="January" sequenceNumber="1539764717">
+<target name="January" sequenceNumber="1641568610">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="javax.measure.unit-api" version="1.0.0.v20170818-1538"/>
-      <unit id="org.apache.commons.math3" version="3.5.0.v20160301-1110"/>
-      <unit id="org.slf4j.api" version="1.7.10.v20170428-1633"/>
+      <unit id="org.apache.commons.math3" version="3.5.0.v20190611-1023"/>
+      <unit id="org.slf4j.api" version="1.7.30.v20200204-2150"/>
       <unit id="org.hamcrest.core" version="1.3.0.v20180420-1519"/>
       <unit id="org.hamcrest.library" version="1.3.0.v20180524-2246"/>
-      <unit id="org.junit" version="4.12.0.v201504281640"/>
-      <repository id="eclipse-orbit-photon" location="http://download.eclipse.org/tools/orbit/downloads/drops/R20180606145124/repository"/>
+      <unit id="org.junit" version="4.13.0.v20200204-1500"/>
+      <repository id="eclipse-orbit-2020-06" location="https://download.eclipse.org/tools/orbit/downloads/drops/R20200529191137/repository"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.equinox.launcher" version="0.0.0"/>
       <unit id="org.eclipse.core.runtime.feature.feature.group" version="0.0.0"/>
-      <repository location="http://download.eclipse.org/eclipse/updates/4.7/R-4.7.2-201711300510/"/>
+      <repository location="https://download.eclipse.org/eclipse/updates/4.16/R-4.16-202006040540"/>
     </location>
   </locations>
 </target>

--- a/releng/org.eclipse.january.releng.target/org.eclipse.january.releng.target.tpd
+++ b/releng/org.eclipse.january.releng.target/org.eclipse.january.releng.target.tpd
@@ -11,7 +11,7 @@
  *******************************************************************************/
 target "January" with source requirements
 
-location "http://download.eclipse.org/tools/orbit/downloads/drops/R20180606145124/repository" eclipse-orbit-photon {
+location "https://download.eclipse.org/tools/orbit/downloads/drops/R20200529191137/repository" eclipse-orbit-2020-06 {
 
 // The versions we point to in Orbit are the versions we have CQs approved for, please
 // raise CQ for items not in this list or version changes
@@ -28,7 +28,7 @@ location "http://download.eclipse.org/tools/orbit/downloads/drops/R2018060614512
 }
 
 // To speed up the build, pull the platform from its own site. version specific and not the EPP site
-location "http://download.eclipse.org/eclipse/updates/4.7/R-4.7.2-201711300510/" { // tycho 1.1 depends on Oxygen.2
+location "https://download.eclipse.org/eclipse/updates/4.16/R-4.16-202006040540" { // tycho 1.1 depends on Oxygen.2
 	org.eclipse.equinox.launcher lazy
 	org.eclipse.core.runtime.feature.feature.group lazy
 }

--- a/releng/org.eclipse.january.releng.target/org.eclipse.january.releng.target.tpd
+++ b/releng/org.eclipse.january.releng.target/org.eclipse.january.releng.target.tpd
@@ -23,7 +23,6 @@ location "http://download.eclipse.org/tools/orbit/downloads/drops/R2018060614512
 
 	// Items below are not depended on by released January bundles, only test ones, so no CQs
 	org.junit [4.12.0,5.0.0)
-	org.mockito [1.9.5,2.0.0)
 	org.hamcrest.core [1.3.0,2.0.0)
 	org.hamcrest.library [1.3.0,2.0.0)
 }

--- a/releng/org.eclipse.january.releng.target/pom.xml
+++ b/releng/org.eclipse.january.releng.target/pom.xml
@@ -18,7 +18,7 @@
 	<parent>
 		<groupId>org.eclipse.january</groupId>
 		<artifactId>org.eclipse.january.releng</artifactId>
-		<version>2.3.0-SNAPSHOT</version>
+		<version>2.3.0</version>
 		<relativePath>../org.eclipse.january.releng</relativePath>
 	</parent>
 </project>

--- a/releng/org.eclipse.january.releng.target/pom.xml
+++ b/releng/org.eclipse.january.releng.target/pom.xml
@@ -18,7 +18,7 @@
 	<parent>
 		<groupId>org.eclipse.january</groupId>
 		<artifactId>org.eclipse.january.releng</artifactId>
-		<version>2.3.0</version>
+		<version>2.3.1-SNAPSHOT</version>
 		<relativePath>../org.eclipse.january.releng</relativePath>
 	</parent>
 </project>

--- a/releng/org.eclipse.january.releng/pom.xml
+++ b/releng/org.eclipse.january.releng/pom.xml
@@ -15,13 +15,13 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.eclipse.january</groupId>
 	<artifactId>org.eclipse.january.releng</artifactId>
-	<version>2.3.0-SNAPSHOT</version>
+	<version>2.3.0</version>
 	<packaging>pom</packaging>
 	<parent>
 		<relativePath>../..</relativePath>
 		<groupId>org.eclipse.january</groupId>
 		<artifactId>org.eclipse.january.root</artifactId>
-		<version>2.3.0-SNAPSHOT</version>
+		<version>2.3.0</version>
 	</parent>
 
 	<properties>
@@ -70,7 +70,7 @@
 						<artifact>
 							<groupId>org.eclipse.january</groupId>
 							<artifactId>org.eclipse.january.releng.target</artifactId>
-							<version>2.3.0-SNAPSHOT</version>
+							<version>2.3.0</version>
 						</artifact>
 					</target>
 					<environments>

--- a/releng/org.eclipse.january.releng/pom.xml
+++ b/releng/org.eclipse.january.releng/pom.xml
@@ -25,7 +25,7 @@
 	</parent>
 
 	<properties>
-		<tycho-version>1.1.0</tycho-version>
+		<tycho-version>1.7.0</tycho-version>
 		<tycho-extras-version>${tycho-version}</tycho-extras-version>
 
 		<eclipse-jarsigner-version>1.1.3</eclipse-jarsigner-version>

--- a/releng/org.eclipse.january.releng/pom.xml
+++ b/releng/org.eclipse.january.releng/pom.xml
@@ -15,13 +15,13 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.eclipse.january</groupId>
 	<artifactId>org.eclipse.january.releng</artifactId>
-	<version>2.3.0</version>
+	<version>2.3.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<parent>
 		<relativePath>../..</relativePath>
 		<groupId>org.eclipse.january</groupId>
 		<artifactId>org.eclipse.january.root</artifactId>
-		<version>2.3.0</version>
+		<version>2.3.1-SNAPSHOT</version>
 	</parent>
 
 	<properties>
@@ -70,7 +70,7 @@
 						<artifact>
 							<groupId>org.eclipse.january</groupId>
 							<artifactId>org.eclipse.january.releng.target</artifactId>
-							<version>2.3.0</version>
+							<version>2.3.1-SNAPSHOT</version>
 						</artifact>
 					</target>
 					<environments>


### PR DESCRIPTION
This corresponds to Eclipse 4.16 and is the last one available for Java 8. Update baseline target platform to that needed for 2.2.2. Also update tycho version and gradle doc, and add javax.annotation dependency for upward compatibility with Java 11.