### PR TITLE
Update target platform to 2020-06

### DIFF
--- a/GRADLE.md
+++ b/GRADLE.md
@@ -16,7 +16,7 @@ is in your repositories{} block
 
 2. Add dependency 
 ~~~~ 
-compile "org.eclipse.january:org.eclipse.january:2.2.0" 
+compile "org.eclipse.january:org.eclipse.january:2.3.0" 
 ~~~~ 
 to your file.
 

--- a/org.eclipse.january.examples/JanuaryExamples.target
+++ b/org.eclipse.january.examples/JanuaryExamples.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/mbarbero/fr.obeo.releng.targetplatform -->
-<target name="JanuaryExamples" sequenceNumber="1568301199">
+<target name="JanuaryExamples" sequenceNumber="1641568610">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.january" version="0.0.0"/>
@@ -9,13 +9,12 @@
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="javax.measure.unit-api" version="1.0.0.v20170818-1538"/>
-      <unit id="org.apache.commons.math3" version="3.5.0.v20160301-1110"/>
-      <unit id="org.slf4j.api" version="1.7.10.v20170428-1633"/>
+      <unit id="org.apache.commons.math3" version="3.5.0.v20190611-1023"/>
+      <unit id="org.slf4j.api" version="1.7.30.v20200204-2150"/>
       <unit id="org.hamcrest.core" version="1.3.0.v20180420-1519"/>
       <unit id="org.hamcrest.library" version="1.3.0.v20180524-2246"/>
-      <unit id="org.junit" version="4.12.0.v201504281640"/>
-      <unit id="org.mockito" version="1.9.5.v201605172210"/>
-      <repository id="eclipse-orbit-photon" location="https://download.eclipse.org/tools/orbit/downloads/drops/R20180606145124/repository"/>
+      <unit id="org.junit" version="4.13.0.v20200204-1500"/>
+      <repository id="eclipse-orbit-2020-06" location="https://download.eclipse.org/tools/orbit/downloads/drops/R20200529191137/repository"/>
     </location>
   </locations>
 </target>

--- a/org.eclipse.january.examples/JanuaryExamples.tpd
+++ b/org.eclipse.january.examples/JanuaryExamples.tpd
@@ -11,7 +11,7 @@ location "https://download.eclipse.org/january/releases/2.3/repository" january-
 	org.eclipse.january lazy
 }
 
-location "https://download.eclipse.org/tools/orbit/downloads/drops/R20180606145124/repository" eclipse-orbit-photon {
+location "https://download.eclipse.org/tools/orbit/downloads/drops/R20200529191137/repository" eclipse-orbit-2020-06 {
 // Core requirements
 	javax.measure.unit-api [1.0.0]
 	org.apache.commons.math3 [3.5.0,3.5.1)
@@ -21,5 +21,4 @@ location "https://download.eclipse.org/tools/orbit/downloads/drops/R201806061451
 	org.hamcrest.core [1.3.0,2.0.0)
 	org.hamcrest.library [1.3.0,2.0.0)
 	org.junit [4.12.0,5.0.0)
-	org.mockito [1.9.5,2.0.0)
 }

--- a/org.eclipse.january.examples/META-INF/MANIFEST.MF
+++ b/org.eclipse.january.examples/META-INF/MANIFEST.MF
@@ -8,3 +8,4 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.junit;bundle-version="[4.12.0,5.0.0)"
 Bundle-Vendor: Eclipse January
 Automatic-Module-Name: org.eclipse.january.examples
+Import-Package: javax.annotation

--- a/org.eclipse.january.test/META-INF/MANIFEST.MF
+++ b/org.eclipse.january.test/META-INF/MANIFEST.MF
@@ -9,3 +9,4 @@ Require-Bundle: org.junit;bundle-version="[4.12.0,5.0.0)",
  org.eclipse.january.asserts;bundle-version="2.3.0"
 Bundle-Vendor: Eclipse January
 Automatic-Module-Name: org.eclipse.january.test
+Import-Package: javax.annotation

--- a/pom.xml
+++ b/pom.xml
@@ -27,9 +27,6 @@
 		<developerConnection>scm:git:git@github.com:eclipse/january.git</developerConnection>
 		<url>https://github.com/eclipse/january.git</url>
 	</scm>
-	<prerequisites>
-		<maven>3.0</maven>
-	</prerequisites>
 
 	<name>The Eclipse January Project</name>
 	<description>Common data structures for Science</description>

--- a/releng/org.eclipse.january.releng.target/january-baseline.target
+++ b/releng/org.eclipse.january.releng.target/january-baseline.target
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/mbarbero/fr.obeo.releng.targetplatform -->
-<target name="January-baseline" sequenceNumber="1561543382">
+<target name="January-baseline" sequenceNumber="1539764717">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.january" version="0.0.0"/>
-      <repository id="january-2.2" location="https://download.eclipse.org/january/releases/2.2/repository/"/>
+      <repository id="january-2.2" location="https://download.eclipse.org/january/releases/2.2.2/repository/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.slf4j.api" version="1.7.2.v20121108-1250"/>
+      <unit id="org.slf4j.api" version="1.7.10.v20170428-1633"/>
       <unit id="org.apache.commons.math3" version="3.5.0.v20160301-1110"/>
-      <repository id="eclipse-orbit-oxygen-sr1" location="https://download.eclipse.org/tools/orbit/downloads/drops/R20170818183741/repository"/>
+      <repository id="eclipse-orbit-photon" location="https://download.eclipse.org/tools/orbit/downloads/drops/R20180606145124/repository"/>
     </location>
   </locations>
 </target>

--- a/releng/org.eclipse.january.releng.target/january-baseline.tpd
+++ b/releng/org.eclipse.january.releng.target/january-baseline.tpd
@@ -11,15 +11,14 @@
  *******************************************************************************/
 target "January-baseline" with source requirements
 
-location "http://download.eclipse.org/january/releases/2.0.0/repository/" january-2.0 {
+location "https://download.eclipse.org/january/releases/2.2.2/repository/" january-2.2 {
 	org.eclipse.january lazy
 }
 
-location "http://download.eclipse.org/tools/orbit/downloads/drops/R20170818183741/repository" eclipse-orbit-oxygen-sr1 {
+location "https://download.eclipse.org/tools/orbit/downloads/drops/R20180606145124/repository" eclipse-orbit-photon {
 
 // The versions we point to in Orbit are the versions we have CQs approved for, please
 // raise CQ for items not in this list or version changes
 	org.slf4j.api [1.7.2,1.7.3) // CQ 11781
 	org.apache.commons.math3 [3.5.0,3.5.1) // CQ 11785
-
 }

--- a/releng/org.eclipse.january.releng.target/org.eclipse.january.releng.target.target
+++ b/releng/org.eclipse.january.releng.target/org.eclipse.january.releng.target.target
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/mbarbero/fr.obeo.releng.targetplatform -->
-<target name="January" sequenceNumber="1539764717">
+<target name="January" sequenceNumber="1641568610">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="javax.measure.unit-api" version="1.0.0.v20170818-1538"/>
-      <unit id="org.apache.commons.math3" version="3.5.0.v20160301-1110"/>
-      <unit id="org.slf4j.api" version="1.7.10.v20170428-1633"/>
+      <unit id="org.apache.commons.math3" version="3.5.0.v20190611-1023"/>
+      <unit id="org.slf4j.api" version="1.7.30.v20200204-2150"/>
       <unit id="org.hamcrest.core" version="1.3.0.v20180420-1519"/>
       <unit id="org.hamcrest.library" version="1.3.0.v20180524-2246"/>
-      <unit id="org.junit" version="4.12.0.v201504281640"/>
-      <repository id="eclipse-orbit-photon" location="http://download.eclipse.org/tools/orbit/downloads/drops/R20180606145124/repository"/>
+      <unit id="org.junit" version="4.13.0.v20200204-1500"/>
+      <repository id="eclipse-orbit-2020-06" location="https://download.eclipse.org/tools/orbit/downloads/drops/R20200529191137/repository"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.equinox.launcher" version="0.0.0"/>
       <unit id="org.eclipse.core.runtime.feature.feature.group" version="0.0.0"/>
-      <repository location="http://download.eclipse.org/eclipse/updates/4.7/R-4.7.2-201711300510/"/>
+      <repository location="https://download.eclipse.org/eclipse/updates/4.16/R-4.16-202006040540"/>
     </location>
   </locations>
 </target>

--- a/releng/org.eclipse.january.releng.target/org.eclipse.january.releng.target.tpd
+++ b/releng/org.eclipse.january.releng.target/org.eclipse.january.releng.target.tpd
@@ -11,7 +11,7 @@
  *******************************************************************************/
 target "January" with source requirements
 
-location "http://download.eclipse.org/tools/orbit/downloads/drops/R20180606145124/repository" eclipse-orbit-photon {
+location "https://download.eclipse.org/tools/orbit/downloads/drops/R20200529191137/repository" eclipse-orbit-2020-06 {
 
 // The versions we point to in Orbit are the versions we have CQs approved for, please
 // raise CQ for items not in this list or version changes
@@ -28,7 +28,7 @@ location "http://download.eclipse.org/tools/orbit/downloads/drops/R2018060614512
 }
 
 // To speed up the build, pull the platform from its own site. version specific and not the EPP site
-location "http://download.eclipse.org/eclipse/updates/4.7/R-4.7.2-201711300510/" { // tycho 1.1 depends on Oxygen.2
+location "https://download.eclipse.org/eclipse/updates/4.16/R-4.16-202006040540" { // tycho 1.1 depends on Oxygen.2
 	org.eclipse.equinox.launcher lazy
 	org.eclipse.core.runtime.feature.feature.group lazy
 }

--- a/releng/org.eclipse.january.releng/pom.xml
+++ b/releng/org.eclipse.january.releng/pom.xml
@@ -25,7 +25,7 @@
 	</parent>
 
 	<properties>
-		<tycho-version>1.1.0</tycho-version>
+		<tycho-version>1.7.0</tycho-version>
 		<tycho-extras-version>${tycho-version}</tycho-extras-version>
 
 		<eclipse-jarsigner-version>1.1.3</eclipse-jarsigner-version>


### PR DESCRIPTION
This corresponds to Eclipse 4.16 and is the last one available for Java 8. Update baseline target platform to that needed for 2.2.2. Also update tycho version and gradle doc, and add javax.annotation dependency for upward compatibility with Java 11