### PR TITLE
Fix jenkins build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,9 +27,6 @@
 		<developerConnection>scm:git:git@github.com:eclipse/january.git</developerConnection>
 		<url>https://github.com/eclipse/january.git</url>
 	</scm>
-	<prerequisites>
-		<maven>3.0</maven>
-	</prerequisites>
 
 	<name>The Eclipse January Project</name>
 	<description>Common data structures for Science</description>

--- a/releng/org.eclipse.january.releng/pom.xml
+++ b/releng/org.eclipse.january.releng/pom.xml
@@ -28,7 +28,7 @@
 		<tycho-version>1.1.0</tycho-version>
 		<tycho-extras-version>${tycho-version}</tycho-extras-version>
 
-		<eclipse-jarsigner-version>1.1.3</eclipse-jarsigner-version>
+		<eclipse-jarsigner-version>1.3.2</eclipse-jarsigner-version>
 		<os-jvm-flags /> <!-- for the default case - see https://wiki.eclipse.org/Tycho/FAQ#How_do_I_add_OS-specific_flags.3F -->
 
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Caused by https://bugs.eclipse.org/bugs/show_bug.cgi?id=565644#c12 so update version of jarsigner to use new infrastructure. Also remove unnecessary prerequisites