### PR TITLE
Fix slicing of metadata in lazy datasets

### DIFF
--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/LazyDatasetTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/LazyDatasetTest.java
@@ -20,6 +20,8 @@ import java.util.Arrays;
 import java.util.Comparator;
 
 import org.eclipse.january.DatasetException;
+import org.eclipse.january.metadata.AxesMetadata;
+import org.eclipse.january.metadata.MetadataFactory;
 import org.junit.Test;
 
 public class LazyDatasetTest {
@@ -680,6 +682,12 @@ public class LazyDatasetTest {
 		Dataset d0 = Random.rand(new int[] {2, 3, 1, 4, 5});
 		d0.setName("random");
 		LazyDataset l0 = LazyDataset.createLazyDataset(d0);
+		AxesMetadata am = MetadataFactory.createMetadata(AxesMetadata.class, 5);
+		DoubleDataset axisB = DatasetFactory.createRange(-1.5, 1, 1);
+		am.setAxis(1, axisB);
+		Dataset axisE = DatasetFactory.createFromObject(new double[] {6, 5, 3, 2, 0});
+		am.setAxis(4, axisE);
+		l0.addMetadata(am);
 
 		for (LDOp op1 : LDOp.values()) {
 			if (op1 == LDOp.SHAPE) {

--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/SliceNDTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/SliceNDTest.java
@@ -9,9 +9,12 @@
 
 package org.eclipse.january.dataset;
 
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 public class SliceNDTest {
@@ -25,17 +28,17 @@ public class SliceNDTest {
 
 		// null dataset
 		slice = new SliceND(null);
-		Assert.assertTrue(slice.isAll());
+		assertTrue(slice.isAll());
 
 		// zero-rank dataset
 		slice = new SliceND(new int[0]);
-		Assert.assertTrue(slice.isAll());
+		assertTrue(slice.isAll());
 
 		step = new int[] {};
 		lstart = new int[] {};
 		lstop = new int[] {};
 		slice = new SliceND(new int[] {}, null, null, step);
-		Assert.assertArrayEquals(new int[] {}, slice.getShape());
+		assertArrayEquals(new int[] {}, slice.getShape());
 
 		try {
 			slice = new SliceND(new int[] {1}, null, null, step);
@@ -62,88 +65,88 @@ public class SliceNDTest {
 		lstart = new int[1];
 		lstop = new int[1];
 		slice = new SliceND(new int[] {7}, null, null, step);
-		Assert.assertArrayEquals(new int[] {4}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {0}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {7}, slice.getStop());
+		assertArrayEquals(new int[] {4}, slice.getShape());
+		assertArrayEquals(new int[] {0}, slice.getStart());
+		assertArrayEquals(new int[] {7}, slice.getStop());
 
 		lstart[0] = 0;
 		slice = new SliceND(new int[] {7}, lstart, null, step);
-		Assert.assertArrayEquals(new int[] {4}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {0}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {7}, slice.getStop());
+		assertArrayEquals(new int[] {4}, slice.getShape());
+		assertArrayEquals(new int[] {0}, slice.getStart());
+		assertArrayEquals(new int[] {7}, slice.getStop());
 
 		lstart[0] = 3;
 		slice = new SliceND(new int[] {7}, lstart, null, step);
-		Assert.assertArrayEquals(new int[] {2}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {3}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {7}, slice.getStop());
+		assertArrayEquals(new int[] {2}, slice.getShape());
+		assertArrayEquals(new int[] {3}, slice.getStart());
+		assertArrayEquals(new int[] {7}, slice.getStop());
 
 		lstart[0] = -4;
 		slice = new SliceND(new int[] {7}, lstart, null, step);
-		Assert.assertArrayEquals(new int[] {2}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {3}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {7}, slice.getStop());
+		assertArrayEquals(new int[] {2}, slice.getShape());
+		assertArrayEquals(new int[] {3}, slice.getStart());
+		assertArrayEquals(new int[] {7}, slice.getStop());
 
 		lstart[0] = -8;
 		slice = new SliceND(new int[] {7}, lstart, null, step);
-		Assert.assertArrayEquals(new int[] {4}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {0}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {7}, slice.getStop());
+		assertArrayEquals(new int[] {4}, slice.getShape());
+		assertArrayEquals(new int[] {0}, slice.getStart());
+		assertArrayEquals(new int[] {7}, slice.getStop());
 
 		lstart[0] = 7;
 		slice = new SliceND(new int[] {7}, lstart, null, step);
-		Assert.assertArrayEquals(new int[] {0}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {7}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {7}, slice.getStop());
+		assertArrayEquals(new int[] {0}, slice.getShape());
+		assertArrayEquals(new int[] {7}, slice.getStart());
+		assertArrayEquals(new int[] {7}, slice.getStop());
 
 		lstart[0] = 8;
 		slice = new SliceND(new int[] {7}, lstart, null, step);
-		Assert.assertArrayEquals(new int[] {0}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {7}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {7}, slice.getStop());
+		assertArrayEquals(new int[] {0}, slice.getShape());
+		assertArrayEquals(new int[] {7}, slice.getStart());
+		assertArrayEquals(new int[] {7}, slice.getStop());
 
 		lstop[0] = 7;
 		slice = new SliceND(new int[] {7}, null, lstop, step);
-		Assert.assertArrayEquals(new int[] {4}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {0}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {7}, slice.getStop());
+		assertArrayEquals(new int[] {4}, slice.getShape());
+		assertArrayEquals(new int[] {0}, slice.getStart());
+		assertArrayEquals(new int[] {7}, slice.getStop());
 
 		lstop[0] = -3;
 		slice = new SliceND(new int[] {7}, null, lstop, step);
-		Assert.assertArrayEquals(new int[] {2}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {0}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {4}, slice.getStop());
+		assertArrayEquals(new int[] {2}, slice.getShape());
+		assertArrayEquals(new int[] {0}, slice.getStart());
+		assertArrayEquals(new int[] {4}, slice.getStop());
 
 		lstop[0] = 0;
 		slice = new SliceND(new int[] {7}, null, lstop, step);
-		Assert.assertArrayEquals(new int[] {0}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {0}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {0}, slice.getStop());
+		assertArrayEquals(new int[] {0}, slice.getShape());
+		assertArrayEquals(new int[] {0}, slice.getStart());
+		assertArrayEquals(new int[] {0}, slice.getStop());
 
 		lstop[0] = -6;
 		slice = new SliceND(new int[] {7}, null, lstop, step);
-		Assert.assertArrayEquals(new int[] {1}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {0}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {1}, slice.getStop());
+		assertArrayEquals(new int[] {1}, slice.getShape());
+		assertArrayEquals(new int[] {0}, slice.getStart());
+		assertArrayEquals(new int[] {1}, slice.getStop());
 
 		lstop[0] = -8;
 		slice = new SliceND(new int[] {7}, null, lstop, step);
-		Assert.assertArrayEquals(new int[] {0}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {0}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {0}, slice.getStop());
+		assertArrayEquals(new int[] {0}, slice.getShape());
+		assertArrayEquals(new int[] {0}, slice.getStart());
+		assertArrayEquals(new int[] {0}, slice.getStop());
 
 		lstop[0] = 9;
 		slice = new SliceND(new int[] {7}, null, lstop, step);
-		Assert.assertArrayEquals(new int[] {4}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {0}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {7}, slice.getStop());
+		assertArrayEquals(new int[] {4}, slice.getShape());
+		assertArrayEquals(new int[] {0}, slice.getStart());
+		assertArrayEquals(new int[] {7}, slice.getStop());
 
 		lstart[0] = 4;
 		lstop[0] = 2;
 		slice = new SliceND(new int[] {7}, lstart, lstop, step);
-		Assert.assertArrayEquals(new int[] {0}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {4}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {4}, slice.getStop());
+		assertArrayEquals(new int[] {0}, slice.getShape());
+		assertArrayEquals(new int[] {4}, slice.getStart());
+		assertArrayEquals(new int[] {4}, slice.getStop());
 
 		step = new int[] {-2};
 		try {
@@ -154,133 +157,133 @@ public class SliceNDTest {
 		}
 
 		slice = new SliceND(new int[] {7}, null, null, step);
-		Assert.assertArrayEquals(new int[] {4}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {6}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {-1}, slice.getStop());
+		assertArrayEquals(new int[] {4}, slice.getShape());
+		assertArrayEquals(new int[] {6}, slice.getStart());
+		assertArrayEquals(new int[] {-1}, slice.getStop());
 
 		lstart[0] = 0;
 		slice = new SliceND(new int[] {7}, lstart, null, step);
-		Assert.assertArrayEquals(new int[] {1}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {0}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {-1}, slice.getStop());
+		assertArrayEquals(new int[] {1}, slice.getShape());
+		assertArrayEquals(new int[] {0}, slice.getStart());
+		assertArrayEquals(new int[] {-1}, slice.getStop());
 
 		lstart[0] = 3;
 		slice = new SliceND(new int[] {7}, lstart, null, step);
-		Assert.assertArrayEquals(new int[] {2}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {3}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {-1}, slice.getStop());
+		assertArrayEquals(new int[] {2}, slice.getShape());
+		assertArrayEquals(new int[] {3}, slice.getStart());
+		assertArrayEquals(new int[] {-1}, slice.getStop());
 
 		lstart[0] = -4;
 		slice = new SliceND(new int[] {7}, lstart, null, step);
-		Assert.assertArrayEquals(new int[] {2}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {3}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {-1}, slice.getStop());
+		assertArrayEquals(new int[] {2}, slice.getShape());
+		assertArrayEquals(new int[] {3}, slice.getStart());
+		assertArrayEquals(new int[] {-1}, slice.getStop());
 
 		lstart[0] = -8;
 		slice = new SliceND(new int[] {7}, lstart, null, step);
-		Assert.assertArrayEquals(new int[] {0}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {-1}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {-1}, slice.getStop());
+		assertArrayEquals(new int[] {0}, slice.getShape());
+		assertArrayEquals(new int[] {-1}, slice.getStart());
+		assertArrayEquals(new int[] {-1}, slice.getStop());
 
 		lstart[0] = -7;
 		slice = new SliceND(new int[] {7}, lstart, null, step);
-		Assert.assertArrayEquals(new int[] {1}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {0}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {-1}, slice.getStop());
+		assertArrayEquals(new int[] {1}, slice.getShape());
+		assertArrayEquals(new int[] {0}, slice.getStart());
+		assertArrayEquals(new int[] {-1}, slice.getStop());
 
 		lstart[0] = 7;
 		slice = new SliceND(new int[] {7}, lstart, null, step);
-		Assert.assertArrayEquals(new int[] {4}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {6}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {-1}, slice.getStop());
+		assertArrayEquals(new int[] {4}, slice.getShape());
+		assertArrayEquals(new int[] {6}, slice.getStart());
+		assertArrayEquals(new int[] {-1}, slice.getStop());
 
 		lstart[0] = 8;
 		slice = new SliceND(new int[] {7}, lstart, null, step);
-		Assert.assertArrayEquals(new int[] {4}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {6}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {-1}, slice.getStop());
+		assertArrayEquals(new int[] {4}, slice.getShape());
+		assertArrayEquals(new int[] {6}, slice.getStart());
+		assertArrayEquals(new int[] {-1}, slice.getStop());
 
 
 		lstop[0] = 0;
 		slice = new SliceND(new int[] {7}, null, lstop, step);
-		Assert.assertArrayEquals(new int[] {3}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {6}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {0}, slice.getStop());
+		assertArrayEquals(new int[] {3}, slice.getShape());
+		assertArrayEquals(new int[] {6}, slice.getStart());
+		assertArrayEquals(new int[] {0}, slice.getStop());
 
 		lstop[0] = 1;
 		slice = new SliceND(new int[] {7}, null, lstop, step);
-		Assert.assertArrayEquals(new int[] {3}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {6}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {1}, slice.getStop());
+		assertArrayEquals(new int[] {3}, slice.getShape());
+		assertArrayEquals(new int[] {6}, slice.getStart());
+		assertArrayEquals(new int[] {1}, slice.getStop());
 
 		lstop[0] = -1;
 		slice = new SliceND(new int[] {7}, null, lstop, step);
-		Assert.assertArrayEquals(new int[] {0}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {6}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {6}, slice.getStop());
+		assertArrayEquals(new int[] {0}, slice.getShape());
+		assertArrayEquals(new int[] {6}, slice.getStart());
+		assertArrayEquals(new int[] {6}, slice.getStop());
 
 		lstop[0] = -2;
 		slice = new SliceND(new int[] {7}, null, lstop, step);
-		Assert.assertArrayEquals(new int[] {1}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {6}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {5}, slice.getStop());
+		assertArrayEquals(new int[] {1}, slice.getShape());
+		assertArrayEquals(new int[] {6}, slice.getStart());
+		assertArrayEquals(new int[] {5}, slice.getStop());
 
 		lstop[0] = -3;
 		slice = new SliceND(new int[] {7}, null, lstop, step);
-		Assert.assertArrayEquals(new int[] {1}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {6}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {4}, slice.getStop());
+		assertArrayEquals(new int[] {1}, slice.getShape());
+		assertArrayEquals(new int[] {6}, slice.getStart());
+		assertArrayEquals(new int[] {4}, slice.getStop());
 
 		lstop[0] = -8;
 		slice = new SliceND(new int[] {7}, null, lstop, step);
-		Assert.assertArrayEquals(new int[] {4}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {6}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {-1}, slice.getStop());
+		assertArrayEquals(new int[] {4}, slice.getShape());
+		assertArrayEquals(new int[] {6}, slice.getStart());
+		assertArrayEquals(new int[] {-1}, slice.getStop());
 
 		lstop[0] = -6;
 		slice = new SliceND(new int[] {7}, null, lstop, step);
-		Assert.assertArrayEquals(new int[] {3}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {6}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {1}, slice.getStop());
+		assertArrayEquals(new int[] {3}, slice.getShape());
+		assertArrayEquals(new int[] {6}, slice.getStart());
+		assertArrayEquals(new int[] {1}, slice.getStop());
 
 		lstop[0] = 8;
 		slice = new SliceND(new int[] {7}, null, lstop, step);
-		Assert.assertArrayEquals(new int[] {0}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {6}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {6}, slice.getStop());
+		assertArrayEquals(new int[] {0}, slice.getShape());
+		assertArrayEquals(new int[] {6}, slice.getStart());
+		assertArrayEquals(new int[] {6}, slice.getStop());
 
 		lstop[0] = -8;
 		slice = new SliceND(new int[] {7}, null, lstop, step);
-		Assert.assertArrayEquals(new int[] {4}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {6}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {-1}, slice.getStop());
+		assertArrayEquals(new int[] {4}, slice.getShape());
+		assertArrayEquals(new int[] {6}, slice.getStart());
+		assertArrayEquals(new int[] {-1}, slice.getStop());
 
 		lstart[0] = 1;
 		lstop[0] = 5;
 		slice = new SliceND(new int[] {7}, lstart, lstop, step);
-		Assert.assertArrayEquals(new int[] {0}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {1}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {1}, slice.getStop());
+		assertArrayEquals(new int[] {0}, slice.getShape());
+		assertArrayEquals(new int[] {1}, slice.getStart());
+		assertArrayEquals(new int[] {1}, slice.getStop());
 
 		slice = new SliceND(new int[] {8, 4}, new int[] {1 , 1}, new int[] {8, 4}, new int[] {3, 1});
-		Assert.assertArrayEquals(new int[] {3, 3}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {1, 1}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {8, 4}, slice.getStop());
+		assertArrayEquals(new int[] {3, 3}, slice.getShape());
+		assertArrayEquals(new int[] {1, 1}, slice.getStart());
+		assertArrayEquals(new int[] {8, 4}, slice.getStop());
 
 		slice = new SliceND(new int[] {8, 4}, new int[] {5 , 1}, new int[] {1, 4}, new int[] {3, 1});
-		Assert.assertArrayEquals(new int[] {0, 3}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {5, 1}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {5, 4}, slice.getStop());
+		assertArrayEquals(new int[] {0, 3}, slice.getShape());
+		assertArrayEquals(new int[] {5, 1}, slice.getStart());
+		assertArrayEquals(new int[] {5, 4}, slice.getStop());
 
 		slice = new SliceND(new int[] {8, 4}, new int[] {5 , 1}, new int[] {1, 4}, new int[] {-3, 1});
-		Assert.assertArrayEquals(new int[] {2, 3}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {5, 1}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {1, 4}, slice.getStop());
+		assertArrayEquals(new int[] {2, 3}, slice.getShape());
+		assertArrayEquals(new int[] {5, 1}, slice.getStart());
+		assertArrayEquals(new int[] {1, 4}, slice.getStop());
 
 		slice = new SliceND(new int[] {8, 4}, new int[] {1 , 1}, new int[] {8, 4}, new int[] {-3, 1});
-		Assert.assertArrayEquals(new int[] {0, 3}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {1, 1}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {1, 4}, slice.getStop());
+		assertArrayEquals(new int[] {0, 3}, slice.getShape());
+		assertArrayEquals(new int[] {1, 1}, slice.getStart());
+		assertArrayEquals(new int[] {1, 4}, slice.getStop());
 	}
 
 	@Test
@@ -313,93 +316,93 @@ public class SliceNDTest {
 		lstart = new int[1];
 		lstop = new int[1];
 		slice = new SliceND(new int[] {7}, new int[] {9}, null, null, step);
-		Assert.assertArrayEquals(new int[] {4}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {0}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {7}, slice.getStop());
+		assertArrayEquals(new int[] {4}, slice.getShape());
+		assertArrayEquals(new int[] {0}, slice.getStart());
+		assertArrayEquals(new int[] {7}, slice.getStop());
 
 		lstart[0] = 0;
 		slice = new SliceND(new int[] {7}, new int[] {9}, lstart, null, step);
-		Assert.assertArrayEquals(new int[] {4}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {0}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {7}, slice.getStop());
+		assertArrayEquals(new int[] {4}, slice.getShape());
+		assertArrayEquals(new int[] {0}, slice.getStart());
+		assertArrayEquals(new int[] {7}, slice.getStop());
 
 		lstart[0] = 3;
 		slice = new SliceND(new int[] {7}, new int[] {9}, lstart, null, step);
-		Assert.assertArrayEquals(new int[] {2}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {3}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {7}, slice.getStop());
+		assertArrayEquals(new int[] {2}, slice.getShape());
+		assertArrayEquals(new int[] {3}, slice.getStart());
+		assertArrayEquals(new int[] {7}, slice.getStop());
 
 		lstart[0] = -4;
 		slice = new SliceND(new int[] {7}, new int[] {9}, lstart, null, step);
-		Assert.assertArrayEquals(new int[] {2}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {3}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {7}, slice.getStop());
+		assertArrayEquals(new int[] {2}, slice.getShape());
+		assertArrayEquals(new int[] {3}, slice.getStart());
+		assertArrayEquals(new int[] {7}, slice.getStop());
 
 		lstart[0] = -8;
 		slice = new SliceND(new int[] {7}, new int[] {9}, lstart, null, step);
-		Assert.assertArrayEquals(new int[] {4}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {0}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {7}, slice.getStop());
+		assertArrayEquals(new int[] {4}, slice.getShape());
+		assertArrayEquals(new int[] {0}, slice.getStart());
+		assertArrayEquals(new int[] {7}, slice.getStop());
 
 		lstart[0] = 7;
 		slice = new SliceND(new int[] {7}, new int[] {9}, lstart, null, step);
-		Assert.assertArrayEquals(new int[] {1}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {7}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {9}, slice.getStop());
-		Assert.assertArrayEquals(new int[] {9}, slice.getSourceShape());
+		assertArrayEquals(new int[] {1}, slice.getShape());
+		assertArrayEquals(new int[] {7}, slice.getStart());
+		assertArrayEquals(new int[] {9}, slice.getStop());
+		assertArrayEquals(new int[] {9}, slice.getSourceShape());
 
 		lstart[0] = 8;
 		slice = new SliceND(new int[] {7}, new int[] {9}, lstart, null, step);
-		Assert.assertArrayEquals(new int[] {1}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {8}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {9}, slice.getStop());
-		Assert.assertArrayEquals(new int[] {9}, slice.getSourceShape());
+		assertArrayEquals(new int[] {1}, slice.getShape());
+		assertArrayEquals(new int[] {8}, slice.getStart());
+		assertArrayEquals(new int[] {9}, slice.getStop());
+		assertArrayEquals(new int[] {9}, slice.getSourceShape());
 
 		lstop[0] = 7;
 		slice = new SliceND(new int[] {7}, new int[] {9}, null, lstop, step);
-		Assert.assertArrayEquals(new int[] {4}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {0}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {7}, slice.getStop());
-		Assert.assertArrayEquals(new int[] {7}, slice.getSourceShape());
+		assertArrayEquals(new int[] {4}, slice.getShape());
+		assertArrayEquals(new int[] {0}, slice.getStart());
+		assertArrayEquals(new int[] {7}, slice.getStop());
+		assertArrayEquals(new int[] {7}, slice.getSourceShape());
 
 		lstop[0] = -3;
 		slice = new SliceND(new int[] {7}, new int[] {9}, null, lstop, step);
-		Assert.assertArrayEquals(new int[] {2}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {0}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {4}, slice.getStop());
+		assertArrayEquals(new int[] {2}, slice.getShape());
+		assertArrayEquals(new int[] {0}, slice.getStart());
+		assertArrayEquals(new int[] {4}, slice.getStop());
 
 		lstop[0] = 0;
 		slice = new SliceND(new int[] {7}, new int[] {9}, null, lstop, step);
-		Assert.assertArrayEquals(new int[] {0}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {0}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {0}, slice.getStop());
+		assertArrayEquals(new int[] {0}, slice.getShape());
+		assertArrayEquals(new int[] {0}, slice.getStart());
+		assertArrayEquals(new int[] {0}, slice.getStop());
 
 		lstop[0] = -6;
 		slice = new SliceND(new int[] {7}, new int[] {9}, null, lstop, step);
-		Assert.assertArrayEquals(new int[] {1}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {0}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {1}, slice.getStop());
+		assertArrayEquals(new int[] {1}, slice.getShape());
+		assertArrayEquals(new int[] {0}, slice.getStart());
+		assertArrayEquals(new int[] {1}, slice.getStop());
 
 		lstop[0] = -8;
 		slice = new SliceND(new int[] {7}, new int[] {9}, null, lstop, step);
-		Assert.assertArrayEquals(new int[] {0}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {0}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {0}, slice.getStop());
-		Assert.assertArrayEquals(new int[] {7}, slice.getSourceShape());
+		assertArrayEquals(new int[] {0}, slice.getShape());
+		assertArrayEquals(new int[] {0}, slice.getStart());
+		assertArrayEquals(new int[] {0}, slice.getStop());
+		assertArrayEquals(new int[] {7}, slice.getSourceShape());
 
 		lstop[0] = 8;
 		slice = new SliceND(new int[] {7}, new int[] {9}, null, lstop, step);
-		Assert.assertArrayEquals(new int[] {4}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {0}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {8}, slice.getStop());
-		Assert.assertArrayEquals(new int[] {8}, slice.getSourceShape());
+		assertArrayEquals(new int[] {4}, slice.getShape());
+		assertArrayEquals(new int[] {0}, slice.getStart());
+		assertArrayEquals(new int[] {8}, slice.getStop());
+		assertArrayEquals(new int[] {8}, slice.getSourceShape());
 
 		lstop[0] = 9;
 		slice = new SliceND(new int[] {7}, new int[] {9}, null, lstop, step);
-		Assert.assertArrayEquals(new int[] {5}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {0}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {9}, slice.getStop());
-		Assert.assertArrayEquals(new int[] {9}, slice.getSourceShape());
+		assertArrayEquals(new int[] {5}, slice.getShape());
+		assertArrayEquals(new int[] {0}, slice.getStart());
+		assertArrayEquals(new int[] {9}, slice.getStop());
+		assertArrayEquals(new int[] {9}, slice.getSourceShape());
 
 		step = new int[] {-2};
 		try {
@@ -410,106 +413,106 @@ public class SliceNDTest {
 		}
 
 		slice = new SliceND(new int[] {7}, new int[] {9}, null, null, step);
-		Assert.assertArrayEquals(new int[] {4}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {6}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {-1}, slice.getStop());
+		assertArrayEquals(new int[] {4}, slice.getShape());
+		assertArrayEquals(new int[] {6}, slice.getStart());
+		assertArrayEquals(new int[] {-1}, slice.getStop());
 
 		lstart[0] = 0;
 		slice = new SliceND(new int[] {7}, new int[] {9}, lstart, null, step);
-		Assert.assertArrayEquals(new int[] {1}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {0}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {-1}, slice.getStop());
+		assertArrayEquals(new int[] {1}, slice.getShape());
+		assertArrayEquals(new int[] {0}, slice.getStart());
+		assertArrayEquals(new int[] {-1}, slice.getStop());
 
 		lstart[0] = 3;
 		slice = new SliceND(new int[] {7}, new int[] {9}, lstart, null, step);
-		Assert.assertArrayEquals(new int[] {2}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {3}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {-1}, slice.getStop());
+		assertArrayEquals(new int[] {2}, slice.getShape());
+		assertArrayEquals(new int[] {3}, slice.getStart());
+		assertArrayEquals(new int[] {-1}, slice.getStop());
 
 		lstart[0] = -4;
 		slice = new SliceND(new int[] {7}, new int[] {9}, lstart, null, step);
-		Assert.assertArrayEquals(new int[] {2}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {3}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {-1}, slice.getStop());
+		assertArrayEquals(new int[] {2}, slice.getShape());
+		assertArrayEquals(new int[] {3}, slice.getStart());
+		assertArrayEquals(new int[] {-1}, slice.getStop());
 
 		lstart[0] = -8;
 		slice = new SliceND(new int[] {7}, new int[] {9}, lstart, null, step);
-		Assert.assertArrayEquals(new int[] {0}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {-1}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {-1}, slice.getStop());
+		assertArrayEquals(new int[] {0}, slice.getShape());
+		assertArrayEquals(new int[] {-1}, slice.getStart());
+		assertArrayEquals(new int[] {-1}, slice.getStop());
 
 		lstart[0] = -7;
 		slice = new SliceND(new int[] {7}, new int[] {9}, lstart, null, step);
-		Assert.assertArrayEquals(new int[] {1}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {0}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {-1}, slice.getStop());
+		assertArrayEquals(new int[] {1}, slice.getShape());
+		assertArrayEquals(new int[] {0}, slice.getStart());
+		assertArrayEquals(new int[] {-1}, slice.getStop());
 
 		lstart[0] = 7;
 		slice = new SliceND(new int[] {7}, new int[] {9}, lstart, null, step);
-		Assert.assertArrayEquals(new int[] {4}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {6}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {-1}, slice.getStop());
+		assertArrayEquals(new int[] {4}, slice.getShape());
+		assertArrayEquals(new int[] {6}, slice.getStart());
+		assertArrayEquals(new int[] {-1}, slice.getStop());
 
 		lstart[0] = 8;
 		slice = new SliceND(new int[] {7}, new int[] {9}, lstart, null, step);
-		Assert.assertArrayEquals(new int[] {4}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {6}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {-1}, slice.getStop());
+		assertArrayEquals(new int[] {4}, slice.getShape());
+		assertArrayEquals(new int[] {6}, slice.getStart());
+		assertArrayEquals(new int[] {-1}, slice.getStop());
 
 
 		lstop[0] = 0;
 		slice = new SliceND(new int[] {7}, new int[] {9}, null, lstop, step);
-		Assert.assertArrayEquals(new int[] {3}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {6}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {0}, slice.getStop());
+		assertArrayEquals(new int[] {3}, slice.getShape());
+		assertArrayEquals(new int[] {6}, slice.getStart());
+		assertArrayEquals(new int[] {0}, slice.getStop());
 
 		lstop[0] = 1;
 		slice = new SliceND(new int[] {7}, new int[] {9}, null, lstop, step);
-		Assert.assertArrayEquals(new int[] {3}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {6}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {1}, slice.getStop());
+		assertArrayEquals(new int[] {3}, slice.getShape());
+		assertArrayEquals(new int[] {6}, slice.getStart());
+		assertArrayEquals(new int[] {1}, slice.getStop());
 
 		lstop[0] = -1;
 		slice = new SliceND(new int[] {7}, new int[] {9}, null, lstop, step);
-		Assert.assertArrayEquals(new int[] {0}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {6}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {6}, slice.getStop());
+		assertArrayEquals(new int[] {0}, slice.getShape());
+		assertArrayEquals(new int[] {6}, slice.getStart());
+		assertArrayEquals(new int[] {6}, slice.getStop());
 
 		lstop[0] = -2;
 		slice = new SliceND(new int[] {7}, new int[] {9}, null, lstop, step);
-		Assert.assertArrayEquals(new int[] {1}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {6}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {5}, slice.getStop());
+		assertArrayEquals(new int[] {1}, slice.getShape());
+		assertArrayEquals(new int[] {6}, slice.getStart());
+		assertArrayEquals(new int[] {5}, slice.getStop());
 
 		lstop[0] = -3;
 		slice = new SliceND(new int[] {7}, new int[] {9}, null, lstop, step);
-		Assert.assertArrayEquals(new int[] {1}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {6}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {4}, slice.getStop());
+		assertArrayEquals(new int[] {1}, slice.getShape());
+		assertArrayEquals(new int[] {6}, slice.getStart());
+		assertArrayEquals(new int[] {4}, slice.getStop());
 
 		lstop[0] = -8;
 		slice = new SliceND(new int[] {7}, new int[] {9}, null, lstop, step);
-		Assert.assertArrayEquals(new int[] {4}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {6}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {-1}, slice.getStop());
+		assertArrayEquals(new int[] {4}, slice.getShape());
+		assertArrayEquals(new int[] {6}, slice.getStart());
+		assertArrayEquals(new int[] {-1}, slice.getStop());
 
 		lstop[0] = -6;
 		slice = new SliceND(new int[] {7}, new int[] {9}, null, lstop, step);
-		Assert.assertArrayEquals(new int[] {3}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {6}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {1}, slice.getStop());
+		assertArrayEquals(new int[] {3}, slice.getShape());
+		assertArrayEquals(new int[] {6}, slice.getStart());
+		assertArrayEquals(new int[] {1}, slice.getStop());
 
 		lstop[0] = 8;
 		slice = new SliceND(new int[] {7}, new int[] {9}, null, lstop, step);
-		Assert.assertArrayEquals(new int[] {0}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {6}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {6}, slice.getStop());
+		assertArrayEquals(new int[] {0}, slice.getShape());
+		assertArrayEquals(new int[] {6}, slice.getStart());
+		assertArrayEquals(new int[] {6}, slice.getStop());
 
 		lstop[0] = -8;
 		slice = new SliceND(new int[] {7}, new int[] {9}, null, lstop, step);
-		Assert.assertArrayEquals(new int[] {4}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {6}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {-1}, slice.getStop());
+		assertArrayEquals(new int[] {4}, slice.getShape());
+		assertArrayEquals(new int[] {6}, slice.getStart());
+		assertArrayEquals(new int[] {-1}, slice.getStop());
 	}
 
 	@Test
@@ -527,34 +530,34 @@ public class SliceNDTest {
 		lstart = new int[1];
 		lstop = new int[1];
 		slice = new SliceND(new int[] {7}, new int[] {-1}, null, null, step);
-		Assert.assertArrayEquals(new int[] {4}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {0}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {7}, slice.getStop());
-		Assert.assertArrayEquals(new int[] {7}, slice.getSourceShape());
+		assertArrayEquals(new int[] {4}, slice.getShape());
+		assertArrayEquals(new int[] {0}, slice.getStart());
+		assertArrayEquals(new int[] {7}, slice.getStop());
+		assertArrayEquals(new int[] {7}, slice.getSourceShape());
 
 		lstart[0] = 0;
 		slice = new SliceND(new int[] {7}, new int[] {-1}, lstart, null, step);
-		Assert.assertArrayEquals(new int[] {4}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {0}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {7}, slice.getStop());
+		assertArrayEquals(new int[] {4}, slice.getShape());
+		assertArrayEquals(new int[] {0}, slice.getStart());
+		assertArrayEquals(new int[] {7}, slice.getStop());
 
 		lstart[0] = 3;
 		slice = new SliceND(new int[] {7}, new int[] {-1}, lstart, null, step);
-		Assert.assertArrayEquals(new int[] {2}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {3}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {7}, slice.getStop());
+		assertArrayEquals(new int[] {2}, slice.getShape());
+		assertArrayEquals(new int[] {3}, slice.getStart());
+		assertArrayEquals(new int[] {7}, slice.getStop());
 
 		lstart[0] = -4;
 		slice = new SliceND(new int[] {7}, new int[] {-1}, lstart, null, step);
-		Assert.assertArrayEquals(new int[] {2}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {3}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {7}, slice.getStop());
+		assertArrayEquals(new int[] {2}, slice.getShape());
+		assertArrayEquals(new int[] {3}, slice.getStart());
+		assertArrayEquals(new int[] {7}, slice.getStop());
 
 		lstart[0] = -8;
 		slice = new SliceND(new int[] {7}, new int[] {-1}, lstart, null, step);
-		Assert.assertArrayEquals(new int[] {4}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {0}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {7}, slice.getStop());
+		assertArrayEquals(new int[] {4}, slice.getShape());
+		assertArrayEquals(new int[] {0}, slice.getStart());
+		assertArrayEquals(new int[] {7}, slice.getStop());
 
 		lstart[0] = 7;
 		try {
@@ -574,71 +577,71 @@ public class SliceNDTest {
 
 		lstop[0] = 7;
 		slice = new SliceND(new int[] {7}, new int[] {-1}, null, lstop, step);
-		Assert.assertArrayEquals(new int[] {4}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {0}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {7}, slice.getStop());
-		Assert.assertArrayEquals(new int[] {7}, slice.getSourceShape());
+		assertArrayEquals(new int[] {4}, slice.getShape());
+		assertArrayEquals(new int[] {0}, slice.getStart());
+		assertArrayEquals(new int[] {7}, slice.getStop());
+		assertArrayEquals(new int[] {7}, slice.getSourceShape());
 
 		lstop[0] = -3;
 		slice = new SliceND(new int[] {7}, new int[] {-1}, null, lstop, step);
-		Assert.assertArrayEquals(new int[] {2}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {0}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {4}, slice.getStop());
+		assertArrayEquals(new int[] {2}, slice.getShape());
+		assertArrayEquals(new int[] {0}, slice.getStart());
+		assertArrayEquals(new int[] {4}, slice.getStop());
 
 		lstop[0] = 0;
 		slice = new SliceND(new int[] {7}, new int[] {-1}, null, lstop, step);
-		Assert.assertArrayEquals(new int[] {0}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {0}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {0}, slice.getStop());
+		assertArrayEquals(new int[] {0}, slice.getShape());
+		assertArrayEquals(new int[] {0}, slice.getStart());
+		assertArrayEquals(new int[] {0}, slice.getStop());
 
 		lstop[0] = -6;
 		slice = new SliceND(new int[] {7}, new int[] {-1}, null, lstop, step);
-		Assert.assertArrayEquals(new int[] {1}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {0}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {1}, slice.getStop());
+		assertArrayEquals(new int[] {1}, slice.getShape());
+		assertArrayEquals(new int[] {0}, slice.getStart());
+		assertArrayEquals(new int[] {1}, slice.getStop());
 
 		lstop[0] = -8;
 		slice = new SliceND(new int[] {7}, new int[] {-1}, null, lstop, step);
-		Assert.assertArrayEquals(new int[] {0}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {0}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {0}, slice.getStop());
+		assertArrayEquals(new int[] {0}, slice.getShape());
+		assertArrayEquals(new int[] {0}, slice.getStart());
+		assertArrayEquals(new int[] {0}, slice.getStop());
 
 		lstop[0] = 8;
 		slice = new SliceND(new int[] {7}, new int[] {-1}, null, lstop, step);
-		Assert.assertArrayEquals(new int[] {4}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {0}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {8}, slice.getStop());
-		Assert.assertArrayEquals(new int[] {8}, slice.getSourceShape());
+		assertArrayEquals(new int[] {4}, slice.getShape());
+		assertArrayEquals(new int[] {0}, slice.getStart());
+		assertArrayEquals(new int[] {8}, slice.getStop());
+		assertArrayEquals(new int[] {8}, slice.getSourceShape());
 
 		lstop[0] = 9;
 		slice = new SliceND(new int[] {7}, new int[] {-1}, null, lstop, step);
-		Assert.assertArrayEquals(new int[] {5}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {0}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {9}, slice.getStop());
-		Assert.assertArrayEquals(new int[] {9}, slice.getSourceShape());
+		assertArrayEquals(new int[] {5}, slice.getShape());
+		assertArrayEquals(new int[] {0}, slice.getStart());
+		assertArrayEquals(new int[] {9}, slice.getStop());
+		assertArrayEquals(new int[] {9}, slice.getSourceShape());
 
 		lstop[0] = 12;
 		slice = new SliceND(new int[] {7}, new int[] {-1}, null, lstop, step);
-		Assert.assertArrayEquals(new int[] {6}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {0}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {12}, slice.getStop());
-		Assert.assertArrayEquals(new int[] {12}, slice.getSourceShape());
+		assertArrayEquals(new int[] {6}, slice.getShape());
+		assertArrayEquals(new int[] {0}, slice.getStart());
+		assertArrayEquals(new int[] {12}, slice.getStop());
+		assertArrayEquals(new int[] {12}, slice.getSourceShape());
 
 		lstart[0] = 2;
 		lstop[0] = 7;
 		slice = new SliceND(new int[] {7}, new int[] {-1}, lstart, lstop, step);
-		Assert.assertArrayEquals(new int[] {3}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {2}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {7}, slice.getStop());
-		Assert.assertArrayEquals(new int[] {7}, slice.getSourceShape());
+		assertArrayEquals(new int[] {3}, slice.getShape());
+		assertArrayEquals(new int[] {2}, slice.getStart());
+		assertArrayEquals(new int[] {7}, slice.getStop());
+		assertArrayEquals(new int[] {7}, slice.getSourceShape());
 
 		lstart[0] = 2;
 		lstop[0] = 12;
 		slice = new SliceND(new int[] {7}, new int[] {-1}, lstart, lstop, step);
-		Assert.assertArrayEquals(new int[] {5}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {2}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {12}, slice.getStop());
-		Assert.assertArrayEquals(new int[] {12}, slice.getSourceShape());
+		assertArrayEquals(new int[] {5}, slice.getShape());
+		assertArrayEquals(new int[] {2}, slice.getStart());
+		assertArrayEquals(new int[] {12}, slice.getStop());
+		assertArrayEquals(new int[] {12}, slice.getSourceShape());
 
 
 		step = new int[] {-2};
@@ -650,106 +653,106 @@ public class SliceNDTest {
 		}
 
 		slice = new SliceND(new int[] {7}, new int[] {-1}, null, null, step);
-		Assert.assertArrayEquals(new int[] {4}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {6}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {-1}, slice.getStop());
+		assertArrayEquals(new int[] {4}, slice.getShape());
+		assertArrayEquals(new int[] {6}, slice.getStart());
+		assertArrayEquals(new int[] {-1}, slice.getStop());
 
 		lstart[0] = 0;
 		slice = new SliceND(new int[] {7}, new int[] {-1}, lstart, null, step);
-		Assert.assertArrayEquals(new int[] {1}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {0}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {-1}, slice.getStop());
+		assertArrayEquals(new int[] {1}, slice.getShape());
+		assertArrayEquals(new int[] {0}, slice.getStart());
+		assertArrayEquals(new int[] {-1}, slice.getStop());
 
 		lstart[0] = 3;
 		slice = new SliceND(new int[] {7}, new int[] {-1}, lstart, null, step);
-		Assert.assertArrayEquals(new int[] {2}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {3}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {-1}, slice.getStop());
+		assertArrayEquals(new int[] {2}, slice.getShape());
+		assertArrayEquals(new int[] {3}, slice.getStart());
+		assertArrayEquals(new int[] {-1}, slice.getStop());
 
 		lstart[0] = -4;
 		slice = new SliceND(new int[] {7}, new int[] {-1}, lstart, null, step);
-		Assert.assertArrayEquals(new int[] {2}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {3}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {-1}, slice.getStop());
+		assertArrayEquals(new int[] {2}, slice.getShape());
+		assertArrayEquals(new int[] {3}, slice.getStart());
+		assertArrayEquals(new int[] {-1}, slice.getStop());
 
 		lstart[0] = -8;
 		slice = new SliceND(new int[] {7}, new int[] {-1}, lstart, null, step);
-		Assert.assertArrayEquals(new int[] {0}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {-1}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {-1}, slice.getStop());
+		assertArrayEquals(new int[] {0}, slice.getShape());
+		assertArrayEquals(new int[] {-1}, slice.getStart());
+		assertArrayEquals(new int[] {-1}, slice.getStop());
 
 		lstart[0] = -7;
 		slice = new SliceND(new int[] {7}, new int[] {-1}, lstart, null, step);
-		Assert.assertArrayEquals(new int[] {1}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {0}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {-1}, slice.getStop());
+		assertArrayEquals(new int[] {1}, slice.getShape());
+		assertArrayEquals(new int[] {0}, slice.getStart());
+		assertArrayEquals(new int[] {-1}, slice.getStop());
 
 		lstart[0] = 7;
 		slice = new SliceND(new int[] {7}, new int[] {-1}, lstart, null, step);
-		Assert.assertArrayEquals(new int[] {4}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {6}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {-1}, slice.getStop());
+		assertArrayEquals(new int[] {4}, slice.getShape());
+		assertArrayEquals(new int[] {6}, slice.getStart());
+		assertArrayEquals(new int[] {-1}, slice.getStop());
 
 		lstart[0] = 8;
 		slice = new SliceND(new int[] {7}, new int[] {-1}, lstart, null, step);
-		Assert.assertArrayEquals(new int[] {4}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {6}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {-1}, slice.getStop());
+		assertArrayEquals(new int[] {4}, slice.getShape());
+		assertArrayEquals(new int[] {6}, slice.getStart());
+		assertArrayEquals(new int[] {-1}, slice.getStop());
 
 
 		lstop[0] = 0;
 		slice = new SliceND(new int[] {7}, new int[] {-1}, null, lstop, step);
-		Assert.assertArrayEquals(new int[] {3}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {6}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {0}, slice.getStop());
+		assertArrayEquals(new int[] {3}, slice.getShape());
+		assertArrayEquals(new int[] {6}, slice.getStart());
+		assertArrayEquals(new int[] {0}, slice.getStop());
 
 		lstop[0] = 1;
 		slice = new SliceND(new int[] {7}, new int[] {-1}, null, lstop, step);
-		Assert.assertArrayEquals(new int[] {3}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {6}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {1}, slice.getStop());
+		assertArrayEquals(new int[] {3}, slice.getShape());
+		assertArrayEquals(new int[] {6}, slice.getStart());
+		assertArrayEquals(new int[] {1}, slice.getStop());
 
 		lstop[0] = -1;
 		slice = new SliceND(new int[] {7}, new int[] {-1}, null, lstop, step);
-		Assert.assertArrayEquals(new int[] {0}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {6}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {6}, slice.getStop());
+		assertArrayEquals(new int[] {0}, slice.getShape());
+		assertArrayEquals(new int[] {6}, slice.getStart());
+		assertArrayEquals(new int[] {6}, slice.getStop());
 
 		lstop[0] = -2;
 		slice = new SliceND(new int[] {7}, new int[] {-1}, null, lstop, step);
-		Assert.assertArrayEquals(new int[] {1}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {6}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {5}, slice.getStop());
+		assertArrayEquals(new int[] {1}, slice.getShape());
+		assertArrayEquals(new int[] {6}, slice.getStart());
+		assertArrayEquals(new int[] {5}, slice.getStop());
 
 		lstop[0] = -3;
 		slice = new SliceND(new int[] {7}, new int[] {-1}, null, lstop, step);
-		Assert.assertArrayEquals(new int[] {1}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {6}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {4}, slice.getStop());
+		assertArrayEquals(new int[] {1}, slice.getShape());
+		assertArrayEquals(new int[] {6}, slice.getStart());
+		assertArrayEquals(new int[] {4}, slice.getStop());
 
 		lstop[0] = -8;
 		slice = new SliceND(new int[] {7}, new int[] {-1}, null, lstop, step);
-		Assert.assertArrayEquals(new int[] {4}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {6}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {-1}, slice.getStop());
+		assertArrayEquals(new int[] {4}, slice.getShape());
+		assertArrayEquals(new int[] {6}, slice.getStart());
+		assertArrayEquals(new int[] {-1}, slice.getStop());
 
 		lstop[0] = -6;
 		slice = new SliceND(new int[] {7}, new int[] {-1}, null, lstop, step);
-		Assert.assertArrayEquals(new int[] {3}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {6}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {1}, slice.getStop());
+		assertArrayEquals(new int[] {3}, slice.getShape());
+		assertArrayEquals(new int[] {6}, slice.getStart());
+		assertArrayEquals(new int[] {1}, slice.getStop());
 
 		lstop[0] = 8;
 		slice = new SliceND(new int[] {7}, new int[] {-1}, null, lstop, step);
-		Assert.assertArrayEquals(new int[] {0}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {6}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {6}, slice.getStop());
+		assertArrayEquals(new int[] {0}, slice.getShape());
+		assertArrayEquals(new int[] {6}, slice.getStart());
+		assertArrayEquals(new int[] {6}, slice.getStop());
 
 		lstop[0] = -8;
 		slice = new SliceND(new int[] {7}, new int[] {-1}, null, lstop, step);
-		Assert.assertArrayEquals(new int[] {4}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {6}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {-1}, slice.getStop());
+		assertArrayEquals(new int[] {4}, slice.getShape());
+		assertArrayEquals(new int[] {6}, slice.getStart());
+		assertArrayEquals(new int[] {-1}, slice.getStop());
 	}
 
 	@Test
@@ -763,137 +766,137 @@ public class SliceNDTest {
 		lstart = new int[] {};
 		lstop = new int[] {};
 		slice = new SliceND(new int[] {}, null, null, step);
-		Assert.assertTrue(slice.isAll());
+		assertTrue(slice.isAll());
 
 		step = new int[] {-1};
 		slice = new SliceND(new int[] {7}, null, null, step);
-		Assert.assertFalse(slice.isAll());
+		assertFalse(slice.isAll());
 
 		lstart = new int[1];
 		lstop = new int[1];
 
 		step = new int[] {2};
 		slice = new SliceND(new int[] {7}, null, null, step);
-		Assert.assertFalse(slice.isAll());
+		assertFalse(slice.isAll());
 
 		lstart[0] = 0;
 		slice = new SliceND(new int[] {7}, lstart, null, step);
-		Assert.assertFalse(slice.isAll());
+		assertFalse(slice.isAll());
 
 		lstart[0] = 3;
 		slice = new SliceND(new int[] {7}, lstart, null, step);
-		Assert.assertFalse(slice.isAll());
+		assertFalse(slice.isAll());
 
 		lstart[0] = -4;
 		slice = new SliceND(new int[] {7}, lstart, null, step);
-		Assert.assertFalse(slice.isAll());
+		assertFalse(slice.isAll());
 
 		lstart[0] = -8;
 		slice = new SliceND(new int[] {7}, lstart, null, step);
-		Assert.assertFalse(slice.isAll());
+		assertFalse(slice.isAll());
 
 		lstart[0] = 7;
 		slice = new SliceND(new int[] {7}, lstart, null, step);
-		Assert.assertFalse(slice.isAll());
+		assertFalse(slice.isAll());
 
 		lstart[0] = 8;
 		slice = new SliceND(new int[] {7}, lstart, null, step);
-		Assert.assertFalse(slice.isAll());
+		assertFalse(slice.isAll());
 
 		lstop[0] = 7;
 		slice = new SliceND(new int[] {7}, null, lstop, step);
-		Assert.assertFalse(slice.isAll());
+		assertFalse(slice.isAll());
 
 		lstop[0] = -3;
 		slice = new SliceND(new int[] {7}, null, lstop, step);
-		Assert.assertFalse(slice.isAll());
+		assertFalse(slice.isAll());
 
 		lstop[0] = 0;
 		slice = new SliceND(new int[] {7}, null, lstop, step);
-		Assert.assertFalse(slice.isAll());
+		assertFalse(slice.isAll());
 
 		lstop[0] = -6;
 		slice = new SliceND(new int[] {7}, null, lstop, step);
-		Assert.assertFalse(slice.isAll());
+		assertFalse(slice.isAll());
 
 		lstop[0] = -8;
 		slice = new SliceND(new int[] {7}, null, lstop, step);
-		Assert.assertFalse(slice.isAll());
+		assertFalse(slice.isAll());
 
 		lstop[0] = 9;
 		slice = new SliceND(new int[] {7}, null, lstop, step);
-		Assert.assertFalse(slice.isAll());
+		assertFalse(slice.isAll());
 
 
 		step = new int[] {-2};
 
 		slice = new SliceND(new int[] {7}, null, null, step);
-		Assert.assertFalse(slice.isAll());
+		assertFalse(slice.isAll());
 
 		lstart[0] = 0;
 		slice = new SliceND(new int[] {7}, lstart, null, step);
-		Assert.assertFalse(slice.isAll());
+		assertFalse(slice.isAll());
 
 		lstart[0] = 3;
 		slice = new SliceND(new int[] {7}, lstart, null, step);
-		Assert.assertFalse(slice.isAll());
+		assertFalse(slice.isAll());
 
 		lstart[0] = -4;
 		slice = new SliceND(new int[] {7}, lstart, null, step);
-		Assert.assertFalse(slice.isAll());
+		assertFalse(slice.isAll());
 
 		lstart[0] = -8;
 		slice = new SliceND(new int[] {7}, lstart, null, step);
-		Assert.assertFalse(slice.isAll());
+		assertFalse(slice.isAll());
 
 		lstart[0] = -7;
 		slice = new SliceND(new int[] {7}, lstart, null, step);
-		Assert.assertFalse(slice.isAll());
+		assertFalse(slice.isAll());
 
 		lstart[0] = 7;
 		slice = new SliceND(new int[] {7}, lstart, null, step);
-		Assert.assertFalse(slice.isAll());
+		assertFalse(slice.isAll());
 
 		lstart[0] = 8;
 		slice = new SliceND(new int[] {7}, lstart, null, step);
-		Assert.assertFalse(slice.isAll());
+		assertFalse(slice.isAll());
 
 
 		lstop[0] = 0;
 		slice = new SliceND(new int[] {7}, null, lstop, step);
-		Assert.assertFalse(slice.isAll());
+		assertFalse(slice.isAll());
 
 		lstop[0] = 1;
 		slice = new SliceND(new int[] {7}, null, lstop, step);
-		Assert.assertFalse(slice.isAll());
+		assertFalse(slice.isAll());
 
 		lstop[0] = -1;
 		slice = new SliceND(new int[] {7}, null, lstop, step);
-		Assert.assertFalse(slice.isAll());
+		assertFalse(slice.isAll());
 
 		lstop[0] = -2;
 		slice = new SliceND(new int[] {7}, null, lstop, step);
-		Assert.assertFalse(slice.isAll());
+		assertFalse(slice.isAll());
 
 		lstop[0] = -3;
 		slice = new SliceND(new int[] {7}, null, lstop, step);
-		Assert.assertFalse(slice.isAll());
+		assertFalse(slice.isAll());
 
 		lstop[0] = -8;
 		slice = new SliceND(new int[] {7}, null, lstop, step);
-		Assert.assertFalse(slice.isAll());
+		assertFalse(slice.isAll());
 
 		lstop[0] = -6;
 		slice = new SliceND(new int[] {7}, null, lstop, step);
-		Assert.assertFalse(slice.isAll());
+		assertFalse(slice.isAll());
 
 		lstop[0] = 8;
 		slice = new SliceND(new int[] {7}, null, lstop, step);
-		Assert.assertFalse(slice.isAll());
+		assertFalse(slice.isAll());
 
 		lstop[0] = -8;
 		slice = new SliceND(new int[] {7}, null, lstop, step);
-		Assert.assertFalse(slice.isAll());
+		assertFalse(slice.isAll());
 	}
 
 	@Test
@@ -916,69 +919,69 @@ public class SliceNDTest {
 
 		lstart = new int[1];
 		slice = new SliceND(new int[] {7}, null, null, step).flip();
-		Assert.assertArrayEquals(new int[] {4}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {6}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {-1}, slice.getStop());
-		Assert.assertArrayEquals(new int[] {-2}, slice.getStep());
+		assertArrayEquals(new int[] {4}, slice.getShape());
+		assertArrayEquals(new int[] {6}, slice.getStart());
+		assertArrayEquals(new int[] {-1}, slice.getStop());
+		assertArrayEquals(new int[] {-2}, slice.getStep());
 		slice.flip();
-		Assert.assertArrayEquals(new int[] {4}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {0}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {8}, slice.getStop());
-		Assert.assertArrayEquals(new int[] {2}, slice.getStep());
+		assertArrayEquals(new int[] {4}, slice.getShape());
+		assertArrayEquals(new int[] {0}, slice.getStart());
+		assertArrayEquals(new int[] {8}, slice.getStop());
+		assertArrayEquals(new int[] {2}, slice.getStep());
 
 		lstart = new int[] {1};
 		slice = new SliceND(new int[] {7}, lstart, null, step).flip();
-		Assert.assertArrayEquals(new int[] {3}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {5}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {-1}, slice.getStop());
-		Assert.assertArrayEquals(new int[] {-2}, slice.getStep());
+		assertArrayEquals(new int[] {3}, slice.getShape());
+		assertArrayEquals(new int[] {5}, slice.getStart());
+		assertArrayEquals(new int[] {-1}, slice.getStop());
+		assertArrayEquals(new int[] {-2}, slice.getStep());
 		slice.flip();
-		Assert.assertArrayEquals(new int[] {3}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {1}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {7}, slice.getStop());
-		Assert.assertArrayEquals(new int[] {2}, slice.getStep());
+		assertArrayEquals(new int[] {3}, slice.getShape());
+		assertArrayEquals(new int[] {1}, slice.getStart());
+		assertArrayEquals(new int[] {7}, slice.getStop());
+		assertArrayEquals(new int[] {2}, slice.getStep());
 
 		lstart = new int[] {6};
 		slice = new SliceND(new int[] {7}, lstart, null, step).flip();
-		Assert.assertArrayEquals(new int[] {1}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {6}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {4}, slice.getStop());
-		Assert.assertArrayEquals(new int[] {-2}, slice.getStep());
+		assertArrayEquals(new int[] {1}, slice.getShape());
+		assertArrayEquals(new int[] {6}, slice.getStart());
+		assertArrayEquals(new int[] {4}, slice.getStop());
+		assertArrayEquals(new int[] {-2}, slice.getStep());
 		slice.flip();
-		Assert.assertArrayEquals(new int[] {1}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {6}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {8}, slice.getStop());
-		Assert.assertArrayEquals(new int[] {2}, slice.getStep());
+		assertArrayEquals(new int[] {1}, slice.getShape());
+		assertArrayEquals(new int[] {6}, slice.getStart());
+		assertArrayEquals(new int[] {8}, slice.getStop());
+		assertArrayEquals(new int[] {2}, slice.getStep());
 
 		step = new int[] {2, -3};
 		lstart = new int[] {3, 4};
 		slice = new SliceND(new int[] {7, 9}, lstart, null, step).flip(0);
-		Assert.assertArrayEquals(new int[] {2, 2}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {5, 4}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {1, -1}, slice.getStop());
-		Assert.assertArrayEquals(new int[] {-2, -3}, slice.getStep());
+		assertArrayEquals(new int[] {2, 2}, slice.getShape());
+		assertArrayEquals(new int[] {5, 4}, slice.getStart());
+		assertArrayEquals(new int[] {1, -1}, slice.getStop());
+		assertArrayEquals(new int[] {-2, -3}, slice.getStep());
 		slice.flip(0);
-		Assert.assertArrayEquals(new int[] {2, 2}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {3, 4}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {7, -1}, slice.getStop());
-		Assert.assertArrayEquals(new int[] {2, -3}, slice.getStep());
+		assertArrayEquals(new int[] {2, 2}, slice.getShape());
+		assertArrayEquals(new int[] {3, 4}, slice.getStart());
+		assertArrayEquals(new int[] {7, -1}, slice.getStop());
+		assertArrayEquals(new int[] {2, -3}, slice.getStep());
 		slice.flip(-2);
-		Assert.assertArrayEquals(new int[] {2, 2}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {5, 4}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {1, -1}, slice.getStop());
-		Assert.assertArrayEquals(new int[] {-2, -3}, slice.getStep());
+		assertArrayEquals(new int[] {2, 2}, slice.getShape());
+		assertArrayEquals(new int[] {5, 4}, slice.getStart());
+		assertArrayEquals(new int[] {1, -1}, slice.getStop());
+		assertArrayEquals(new int[] {-2, -3}, slice.getStep());
 		slice.flip(0);
 
 		slice.flip();
-		Assert.assertArrayEquals(new int[] {2, 2}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {5, 1}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {1, 7}, slice.getStop());
-		Assert.assertArrayEquals(new int[] {-2, 3}, slice.getStep());
+		assertArrayEquals(new int[] {2, 2}, slice.getShape());
+		assertArrayEquals(new int[] {5, 1}, slice.getStart());
+		assertArrayEquals(new int[] {1, 7}, slice.getStop());
+		assertArrayEquals(new int[] {-2, 3}, slice.getStep());
 		slice.flip();
-		Assert.assertArrayEquals(new int[] {2, 2}, slice.getShape());
-		Assert.assertArrayEquals(new int[] {3, 4}, slice.getStart());
-		Assert.assertArrayEquals(new int[] {7, -1}, slice.getStop());
-		Assert.assertArrayEquals(new int[] {2, -3}, slice.getStep());
+		assertArrayEquals(new int[] {2, 2}, slice.getShape());
+		assertArrayEquals(new int[] {3, 4}, slice.getStart());
+		assertArrayEquals(new int[] {7, -1}, slice.getStop());
+		assertArrayEquals(new int[] {2, -3}, slice.getStep());
 	}
 
 	/**
@@ -991,59 +994,59 @@ public class SliceNDTest {
 	public void testSliceNDNegativeStepEndPoints() {
 		// ::-1 => 511:-1:-1
 		SliceND slice = new SliceND(new int[] {512}, null, null, new int[] {-1});
-		Assert.assertEquals(511, slice.getStart()[0]);
-		Assert.assertEquals(512, slice.getShape()[0]);
-		Assert.assertEquals(-1, slice.getStop()[0]);
+		assertEquals(511, slice.getStart()[0]);
+		assertEquals(512, slice.getShape()[0]);
+		assertEquals(-1, slice.getStop()[0]);
 
 		// :-1:-1 => 511:511:-1
 		slice = new SliceND(new int[] {512}, null, new int[] {-1}, new int[] {-1});
-		Assert.assertEquals(511, slice.getStart()[0]);
-		Assert.assertEquals(0, slice.getShape()[0]);
-		Assert.assertEquals(511, slice.getStop()[0]);
+		assertEquals(511, slice.getStart()[0]);
+		assertEquals(0, slice.getShape()[0]);
+		assertEquals(511, slice.getStop()[0]);
 
 		// :-513:-1 => 511:-1:-1
 		slice = new SliceND(new int[] {512}, null, new int[] {-513}, new int[] {-1});
-		Assert.assertEquals(511, slice.getStart()[0]);
-		Assert.assertEquals(512, slice.getShape()[0]);
-		Assert.assertEquals(-1, slice.getStop()[0]);
+		assertEquals(511, slice.getStart()[0]);
+		assertEquals(512, slice.getShape()[0]);
+		assertEquals(-1, slice.getStop()[0]);
 
 		// 511::-1 => 511:-1:-1
 		slice = new SliceND(new int[] {512}, new int[] {511}, null, new int[] {-1});
-		Assert.assertEquals(511, slice.getStart()[0]);
-		Assert.assertEquals(512, slice.getShape()[0]);
-		Assert.assertEquals(-1, slice.getStop()[0]);
+		assertEquals(511, slice.getStart()[0]);
+		assertEquals(512, slice.getShape()[0]);
+		assertEquals(-1, slice.getStop()[0]);
 
 		// 511:-1:-1 => 511:511:-1
 		slice = new SliceND(new int[] {512}, new int[] {511}, new int[] {-1}, new int[] {-1});
-		Assert.assertEquals(511, slice.getStart()[0]);
-		Assert.assertEquals(0, slice.getShape()[0]);
-		Assert.assertEquals(511, slice.getStop()[0]);
+		assertEquals(511, slice.getStart()[0]);
+		assertEquals(0, slice.getShape()[0]);
+		assertEquals(511, slice.getStop()[0]);
 
 		// 511:-513:-1 => 511:-1:-1
 		slice = new SliceND(new int[] {512}, new int[] {511}, new int[] {-513}, new int[] {-1});
-		Assert.assertEquals(511, slice.getStart()[0]);
-		Assert.assertEquals(512, slice.getShape()[0]);
-		Assert.assertEquals(-1, slice.getStop()[0]);
+		assertEquals(511, slice.getStart()[0]);
+		assertEquals(512, slice.getShape()[0]);
+		assertEquals(-1, slice.getStop()[0]);
 	}
 
 	@Test
 	public void testSliceWithinShape() {
-		Assert.assertTrue(SliceND.isSliceWithinShape(0, 0, 0, 1));
+		assertTrue(SliceND.isSliceWithinShape(0, 0, 0, 1));
 
-		Assert.assertTrue(SliceND.isSliceWithinShape(5, 0, 5, 1));
-		Assert.assertTrue(SliceND.isSliceWithinShape(5, 1, 1, 1));
-		Assert.assertTrue(SliceND.isSliceWithinShape(5, 1, 5, 1));
-		Assert.assertTrue(SliceND.isSliceWithinShape(5, 4, 4, 1));
-		Assert.assertFalse(SliceND.isSliceWithinShape(5, 5, 5, 1));
-		Assert.assertFalse(SliceND.isSliceWithinShape(5, 2, 1, 1));
+		assertTrue(SliceND.isSliceWithinShape(5, 0, 5, 1));
+		assertTrue(SliceND.isSliceWithinShape(5, 1, 1, 1));
+		assertTrue(SliceND.isSliceWithinShape(5, 1, 5, 1));
+		assertTrue(SliceND.isSliceWithinShape(5, 4, 4, 1));
+		assertFalse(SliceND.isSliceWithinShape(5, 5, 5, 1));
+		assertFalse(SliceND.isSliceWithinShape(5, 2, 1, 1));
 
-		Assert.assertTrue(SliceND.isSliceWithinShape(5, 4, -1, -1));
-		Assert.assertTrue(SliceND.isSliceWithinShape(5, 1, 1, -1));
-		Assert.assertTrue(SliceND.isSliceWithinShape(5, 4, 0, -1));
-		Assert.assertTrue(SliceND.isSliceWithinShape(5, 4, 4, -1));
-		Assert.assertFalse(SliceND.isSliceWithinShape(5, 5, 5, -1));
-		Assert.assertFalse(SliceND.isSliceWithinShape(5, -1, -1, -1));
-		Assert.assertFalse(SliceND.isSliceWithinShape(5, 1, 2, -1));
+		assertTrue(SliceND.isSliceWithinShape(5, 4, -1, -1));
+		assertTrue(SliceND.isSliceWithinShape(5, 1, 1, -1));
+		assertTrue(SliceND.isSliceWithinShape(5, 4, 0, -1));
+		assertTrue(SliceND.isSliceWithinShape(5, 4, 4, -1));
+		assertFalse(SliceND.isSliceWithinShape(5, 5, 5, -1));
+		assertFalse(SliceND.isSliceWithinShape(5, -1, -1, -1));
+		assertFalse(SliceND.isSliceWithinShape(5, 1, 2, -1));
 	}
 
 	@Test

--- a/org.eclipse.january/src/org/eclipse/january/dataset/LazyDatasetBase.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/LazyDatasetBase.java
@@ -499,7 +499,7 @@ public abstract class LazyDatasetBase implements ILazyDataset, Serializable {
 				lz = lz.getSliceView(nslice);
 				shape = nslice.getShape();
 			}
-			if (lz.getSize() == oSize) {
+			if (lz.getSize() == oSize && Arrays.equals(shape, oShape)) {
 				nslice = slice;
 			} else {
 				nslice = slice.clone();

--- a/org.eclipse.january/src/org/eclipse/january/dataset/ShapeUtils.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/ShapeUtils.java
@@ -627,7 +627,7 @@ public class ShapeUtils {
 		int or = oldShape.length;
 		int[] newShape = new int[nr];
 		int di = 0;
-		for (int i = 0, si = 0; i < (or+1) && si <= or && di < nr; i++) {
+		for (int i = 0, si = 0; i < padding.length && si <= or && di < nr; i++) {
 			int c = padding[i];
 			if (c == 0) {
 				newShape[di++] = oldShape[si++];

--- a/org.eclipse.january/src/org/eclipse/january/dataset/SliceND.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/SliceND.java
@@ -437,7 +437,7 @@ public class SliceND {
 				}
 				for (int i = 0; i < shape.length; i++) {
 					int s = shape[i];
-					if (!isSliceWithinShape(s, lstart[i], lstop[i], lstep[i])) {
+					if ((s > 1 || s < lshape[i]) && !isSliceWithinShape(s, lstart[i], lstop[i], lstep[i])) {
 						throw new IllegalArgumentException("Updated source shape must be outside latest slice");
 					}
 				}


### PR DESCRIPTION
Add axes metadata to test, convert test method calls to static imports