### PR TITLE
Fix exception raised when taking slice view of large lazy dataset

### DIFF
--- a/org.eclipse.january.test/src/org/eclipse/january/dataset/LazyDatasetTest.java
+++ b/org.eclipse.january.test/src/org/eclipse/january/dataset/LazyDatasetTest.java
@@ -14,6 +14,7 @@ import static org.eclipse.january.asserts.TestUtils.verbosePrintf;
 import static org.eclipse.january.asserts.TestUtils.verbosePrintln;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
 import java.util.Arrays;
@@ -218,6 +219,14 @@ public class LazyDatasetTest {
 
 		l = ld.getSliceView(new SliceND(ld.getShape()));
 		assertEquals("Full slice", d, l.getSlice());
+	}
+
+	@Test
+	public void testLargeLazySliceView() throws DatasetException {
+		ILazyDataset lazyRand = Random.lazyRand(new int[] {2000,2000,2000});
+		IDataset r = lazyRand.getSlice(new Slice(1));
+		assertEquals(2000*2000, r.getSize());
+		assertNotNull(lazyRand.getSliceView()); // should not fail
 	}
 
 	@Test

--- a/org.eclipse.january/src/org/eclipse/january/dataset/PositionIterator.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/PositionIterator.java
@@ -149,7 +149,7 @@ public class PositionIterator extends IndexIterator {
 
 		pos = new int[rank];
 
-		zero = ShapeUtils.calcSize(shape) == 0;
+		zero = ShapeUtils.isZeroSize(shape);
 
 		reset();
 	}

--- a/org.eclipse.january/src/org/eclipse/january/dataset/ShapeUtils.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/ShapeUtils.java
@@ -74,6 +74,31 @@ public class ShapeUtils {
 	}
 
 	/**
+	 * Check if size is zero
+	 * @param shape dataset shape
+	 * @return true if shape is null or any dimension in shape is zero
+	 * @since 2.3
+	 */
+	public static boolean isZeroSize(final int[] shape) {
+		if (shape == null) { // special case of null-shaped
+			return true;
+		}
+
+		final int rank = shape.length;
+		if (rank == 0) { // special case of zero-rank shape
+			return false;
+		}
+	
+		for (int i = 0; i < rank; i++) {
+			if (shape[i] == 0) {
+				return true;
+			}
+		}
+	
+		return false;
+	}
+
+	/**
 	 * Check if shapes are broadcast compatible
 	 * 
 	 * @param ashape first shape

--- a/org.eclipse.january/src/org/eclipse/january/dataset/SliceND.java
+++ b/org.eclipse.january/src/org/eclipse/january/dataset/SliceND.java
@@ -484,7 +484,7 @@ public class SliceND {
 			return true;
 		}
 
-		boolean allData = Arrays.equals(oshape, lshape) && ShapeUtils.calcSize(oshape) > 0;
+		boolean allData = Arrays.equals(oshape, lshape) && !ShapeUtils.isZeroSize(oshape);
 		if (allData) {
 			for (int i = 0; i < lshape.length; i++) {
 				if (lstep[i] < 0) {


### PR DESCRIPTION
Add and use method to check for zero-sized shapes, and add tests